### PR TITLE
Drop ImageNet example's CPU support

### DIFF
--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -85,7 +85,7 @@ def main():
     # Check if GPU is available
     # (ImageNet example does not support CPU execution)
     if not chainer.cuda.available:
-        raise RuntimeError("Error: ImageNet requires GPU support.\n")
+        raise RuntimeError("ImageNet requires GPU support.")
 
     archs = {
         'alex': alex.Alex,


### PR DESCRIPTION
ImageNet example requires GPU, so this PR fixes the issue #22 by modifying the example as the following
(1) removed `--gpu` flag from train_imagenet.py
(2) Print an error message when `chainer.cuda` is not available.