### PR TITLE
Changed MPI versions and MNIST epochs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ python:
 
 env:
   - MPI="mpich-3.0.4"
-  - MPI="mpich-3.1"
   - MPI="mpich-3.2"
   - MPI="openmpi-1.6.5"
-  - MPI="openmpi-1.8.8"
-  - MPI="openmpi-1.10.6"
+  - MPI="openmpi-1.10.3"
   
 
 cache:

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -30,7 +30,7 @@ class TestMNIST(unittest.TestCase):
     def test_mnist(self, display_log=True):
         # This test file is intended to be run on Travis-CI and
         # GPU is not used for now.
-        epoch = 10
+        epoch = 5
         batchsize = 100
         n_units = 100
 


### PR DESCRIPTION
Tests on Travis CI takes long time (5min-) and it would be probably longer in future.
One of the reasons is that the test matrix is large due to check multiple MPI versions.
We check 6 versions of MPI (3 Open MPI and 3 MPICH) but it seems we are doing too much.

Chainer officially supports Ubuntu 14.04 LTS (trusty) and CentOS 7. 
The standard MPI versions of the two platforms are:

* trusty
    * Open MPI 1.6.5
    * mpich 3.0.4
* CentOS 7
    * Open MPI 1.10.3-3
    * mpich 3.0.4, 3.2

Thus, to reduce Travis CI load, we can drop Open MPI 1.8 and mpich 3.1 tests.

In addition, we run 10 epochs of MNIST, but it actually takes only 5 epochs until the accuracy saturates. So we can reduce the number of epochs.


