### PR TITLE
Improve message mnist example

### DIFF
--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -52,7 +52,6 @@ def main():
         if args.communicator == 'naive':
             print("Error: 'naive' communicator does not support GPU.\n")
             exit(-1)
-        print('Using {} communicator'.format(args.communicator))
         comm = chainermn.create_communicator(args.communicator)
         device = comm.intra_rank
     else:
@@ -63,10 +62,15 @@ def main():
         device = -1
 
     if comm.mpi_comm.rank == 0:
-        print('GPU: {}'.format(device))
-        print('# unit: {}'.format(args.unit))
-        print('# Minibatch-size: {}'.format(args.batchsize))
-        print('# epoch: {}'.format(args.epoch))
+        from mpi4py import MPI
+        print('==========================================')
+        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Rank 0 is using GPU {}'.format(device))
+        print('Using {} communicator'.format(args.communicator))
+        print('Num unit: {}'.format(args.unit))
+        print('Num Minibatch-size: {}'.format(args.batchsize))
+        print('Num epoch: {}'.format(args.epoch))
+        print('==========================================')
 
     model = L.Classifier(MLP(args.unit, 10))
     if device >= 0:

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -8,6 +8,7 @@ import chainer.functions as F
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
+from mpi4py import MPI
 
 import chainermn
 
@@ -62,7 +63,6 @@ def main():
         device = -1
 
     if comm.mpi_comm.rank == 0:
-        from mpi4py import MPI
         print('==========================================')
         print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
         if args.gpu:

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -65,7 +65,8 @@ def main():
         from mpi4py import MPI
         print('==========================================')
         print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
-        print('Rank 0 is using GPU {}'.format(device))
+        if args.gpu:
+            print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))
         print('Num unit: {}'.format(args.unit))
         print('Num Minibatch-size: {}'.format(args.batchsize))


### PR DESCRIPTION
Log messages from the MNIST examples were not very clear, especially when a user is facing a trouble.
This PR updates the log message to be more friendly and helpful.
 - The message is now printed only once (communicator message was printed by each process)
 - Number of processes is printed (for troubleshooting)
 - Formatted more prettier

```
==========================================
Num process (COMM_WORLD): 2
Using GPUs
Using hierarchical communicator
Num unit: 1000
Num Minibatch-size: 100
Num epoch: 5
==========================================
```
