### PR TITLE
MultiNodeChainList with self branching

### DIFF
--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -77,8 +77,14 @@ class Recv(chainer.Function):
         xp = cuda.get_array_module(*inputs)
         gw, = grad_outputs
         self.comm.send(gw, self.peer_rank, self.peer_tag)
-        dummy_var = xp.array([[]], dtype=xp.float32)
-        return dummy_var
+
+        if inputs == ():
+            dummy_var = xp.array([], dtype=xp.float32)
+        else:
+            var, = inputs
+            dummy_var = xp.zeros(var.shape, dtype=xp.float32)
+
+        return dummy_var,
 
 
 def send(x, communicator, rank, tag=0):

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -104,6 +104,7 @@ def send(x, communicator, rank, tag=0):
 
     """
     chainer.utils.experimental('chainermn.functions.send')
+    assert rank != communicator.rank
     return Send(communicator, peer_rank=rank, peer_tag=tag)(x)
 
 
@@ -136,6 +137,7 @@ def recv(communicator, rank, delegate_variable=None, tag=0, device=-1):
 
     """
     chainer.utils.experimental('chainermn.functions.recv')
+    assert rank != communicator.rank
     if delegate_variable is None:
         return Recv(
             communicator,

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -110,7 +110,12 @@ def send(x, communicator, rank, tag=0):
 
     """
     chainer.utils.experimental('chainermn.functions.send')
-    assert rank != communicator.rank
+
+    if rank == communicator.rank:
+        raise ValueError(
+            'rank must be different from communicator rank, '
+            'otherwise deadlock occurs')
+
     return Send(communicator, peer_rank=rank, peer_tag=tag)(x)
 
 
@@ -143,7 +148,12 @@ def recv(communicator, rank, delegate_variable=None, tag=0, device=-1):
 
     """
     chainer.utils.experimental('chainermn.functions.recv')
-    assert rank != communicator.rank
+
+    if rank == communicator.rank:
+        raise ValueError(
+            'rank must be different from communicator rank, '
+            'otherwise deadlock occurs')
+
     if delegate_variable is None:
         return Recv(
             communicator,

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -1,4 +1,4 @@
-import queue
+from six.moves import queue
 
 import chainer
 import chainermn

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -128,6 +128,13 @@ class MultiNodeChainList(chainer.ChainList):
         if isinstance(rank_out, int):
             rank_out = [rank_out]
 
+        if rank_out is None:
+            for _, _rank_out in self._rank_inouts:
+                if _rank_out is None:
+                    raise ValueError(
+                        'MultiNodeChainList cannot have more than two '
+                        'computational graph component whose rank_out is None'
+
         self._rank_inouts.append((rank_in, rank_out))
 
     def __call__(self, *inputs):

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -133,7 +133,7 @@ class MultiNodeChainList(chainer.ChainList):
                 if _rank_out is None:
                     raise ValueError(
                         'MultiNodeChainList cannot have more than two '
-                        'computational graph component whose rank_out is None'
+                        'computational graph component whose rank_out is None')
 
         self._rank_inouts.append((rank_in, rank_out))
 

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -176,8 +176,7 @@ class MultiNodeChainList(chainer.ChainList):
                     # component to be executed in the last to avoid dead-lock.
                     delegate_variable = _x
 
-                # Prevent "double-backwarding," i.e., backprop
-                # the same edge more than twice.
+                # Guarantee backprop on the same edge exactly once.
                 delegate_variable = None
 
                 # Actual forward.

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -221,6 +221,8 @@ class MultiNodeChainList(chainer.ChainList):
                             x, self._comm,
                             rank=_rank_out)
 
+        assert comm_queue.empty()
+
         # Return.
         if y is delegate_variable:
             # The last computational graph component returns model output.

--- a/chainermn/link.py
+++ b/chainermn/link.py
@@ -221,7 +221,10 @@ class MultiNodeChainList(chainer.ChainList):
                             x, self._comm,
                             rank=_rank_out)
 
-        assert comm_queue.empty()
+        if not comm_queue.empty():
+            raise ValueError(
+                'Communication queue is not empty at the end of forward.'
+                'Make sure if all rank_in and rank_out correspond each other.')
 
         # Return.
         if y is delegate_variable:

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -92,6 +92,15 @@ class BranchParent1(chainermn.MultiNodeChainList):
         self.add_link(BranchSubB(size), rank_in=rank_children, rank_out=None)
 
 
+class BranchParent2(chainermn.MultiNodeChainList):
+    def __init__(self, size, comm, rank_children):
+        super(BranchParent2, self).__init__(comm=comm)
+        ranks = [0] + rank_children
+        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
+        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
+
+
 class BranchChild(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_parent):
         super(BranchChild, self).__init__(comm=comm)
@@ -198,3 +207,6 @@ class TestMultiNodeChain(unittest.TestCase):
 
     def test_branching_model1(self):
         self.check_branching_model(BranchParent1)
+
+    def test_branching_model2(self):
+        self.check_branching_model(BranchParent2)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -95,28 +95,28 @@ class BranchParent1(chainermn.MultiNodeChainList):
 class BranchParent2(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_children):
         super(BranchParent2, self).__init__(comm=comm)
-        ranks = [0] + rank_children
+        ranks = [comm.rank] + rank_children
         self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
-        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
         self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
 
 
 class BranchParent3(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_children):
         super(BranchParent3, self).__init__(comm=comm)
-        ranks = rank_children + [0]
+        ranks = rank_children + [comm.rank]
         self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
-        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
         self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
 
 
 class BranchParent4(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_children):
         super(BranchParent4, self).__init__(comm=comm)
-        ranks = rank_children + [0]
+        ranks = rank_children + [comm.rank]
         ranks = ranks[1:] + ranks[0:1]
         self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
-        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
         self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
 
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -101,6 +101,15 @@ class BranchParent2(chainermn.MultiNodeChainList):
         self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
 
 
+class BranchParent3(chainermn.MultiNodeChainList):
+    def __init__(self, size, comm, rank_children):
+        super(BranchParent3, self).__init__(comm=comm)
+        ranks = rank_children + [0]
+        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
+        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
+
+
 class BranchChild(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_parent):
         super(BranchChild, self).__init__(comm=comm)
@@ -210,3 +219,6 @@ class TestMultiNodeChain(unittest.TestCase):
 
     def test_branching_model2(self):
         self.check_branching_model(BranchParent2)
+
+    def test_branching_model3(self):
+        self.check_branching_model(BranchParent3)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -110,6 +110,16 @@ class BranchParent3(chainermn.MultiNodeChainList):
         self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
 
 
+class BranchParent4(chainermn.MultiNodeChainList):
+    def __init__(self, size, comm, rank_children):
+        super(BranchParent4, self).__init__(comm=comm)
+        ranks = rank_children + [0]
+        ranks = ranks[1:] + ranks[0:1]
+        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
+        self.add_link(BranchSubA(size), rank_in=0, rank_out=0)
+        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
+
+
 class BranchChild(chainermn.MultiNodeChainList):
     def __init__(self, size, comm, rank_parent):
         super(BranchChild, self).__init__(comm=comm)
@@ -222,3 +232,6 @@ class TestMultiNodeChain(unittest.TestCase):
 
     def test_branching_model3(self):
         self.check_branching_model(BranchParent3)
+
+    def test_branching_model4(self):
+        self.check_branching_model(BranchParent4)


### PR DESCRIPTION
In #98 , `MultiNodeChainList` does not allow to send / recv to the same process (see https://github.com/chainer/chainermn/blob/master/chainermn/link.py#L129).
This pull request extends `MultiNodeChainList` a little bit to allow it.
See examples in `test_link.py`:
```python 
class BranchParent2(chainermn.MultiNodeChainList):
    def __init__(self, size, comm, rank_children):
        super(BranchParent2, self).__init__(comm=comm)
        ranks = [comm.rank] + rank_children
        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)


class BranchParent3(chainermn.MultiNodeChainList):
    def __init__(self, size, comm, rank_children):
        super(BranchParent3, self).__init__(comm=comm)
        ranks = rank_children + [comm.rank]
        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)


class BranchParent4(chainermn.MultiNodeChainList):
    def __init__(self, size, comm, rank_children):
        super(BranchParent4, self).__init__(comm=comm)
        ranks = rank_children + [comm.rank]
        ranks = ranks[1:] + ranks[0:1]
        self.add_link(BranchSubA(size), rank_in=None, rank_out=ranks)
        self.add_link(BranchSubA(size), rank_in=comm.rank, rank_out=comm.rank)
        self.add_link(BranchSubB(size), rank_in=ranks, rank_out=None)
```
In these examples, we can specify `comm.rank` (the rank on which the models would be instantiated) for `rank_in` or `rank_out`.