### PR TITLE
Fix imagenet models for v2

### DIFF
--- a/examples/imagenet/models_v2/alex.py
+++ b/examples/imagenet/models_v2/alex.py
@@ -10,16 +10,16 @@ class Alex(chainer.Chain):
     insize = 227
 
     def __init__(self):
-        super(Alex, self).__init__(
-            conv1=L.Convolution2D(None, 96, 11, stride=4),
-            conv2=L.Convolution2D(None, 256,  5, pad=2),
-            conv3=L.Convolution2D(None, 384,  3, pad=1),
-            conv4=L.Convolution2D(None, 384,  3, pad=1),
-            conv5=L.Convolution2D(None, 256,  3, pad=1),
-            fc6=L.Linear(None, 4096),
-            fc7=L.Linear(None, 4096),
-            fc8=L.Linear(None, 1000),
-        )
+        super(Alex, self).__init__()
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(None, 96, 11, stride=4)
+            self.conv2 = L.Convolution2D(None, 256, 5, pad=2)
+            self.conv3 = L.Convolution2D(None, 384, 3, pad=1)
+            self.conv4 = L.Convolution2D(None, 384, 3, pad=1)
+            self.conv5 = L.Convolution2D(None, 256, 3, pad=1)
+            self.fc6 = L.Linear(None, 4096)
+            self.fc7 = L.Linear(None, 4096)
+            self.fc8 = L.Linear(None, 1000)
 
     def __call__(self, x, t):
         h = F.max_pooling_2d(F.local_response_normalization(

--- a/examples/imagenet/models_v2/googlenet.py
+++ b/examples/imagenet/models_v2/googlenet.py
@@ -8,29 +8,29 @@ class GoogLeNet(chainer.Chain):
     insize = 224
 
     def __init__(self):
-        super(GoogLeNet, self).__init__(
-            conv1=L.Convolution2D(None,  64, 7, stride=2, pad=3),
-            conv2_reduce=L.Convolution2D(None,  64, 1),
-            conv2=L.Convolution2D(None, 192, 3, stride=1, pad=1),
-            inc3a=L.Inception(None,  64,  96, 128, 16,  32,  32),
-            inc3b=L.Inception(None, 128, 128, 192, 32,  96,  64),
-            inc4a=L.Inception(None, 192,  96, 208, 16,  48,  64),
-            inc4b=L.Inception(None, 160, 112, 224, 24,  64,  64),
-            inc4c=L.Inception(None, 128, 128, 256, 24,  64,  64),
-            inc4d=L.Inception(None, 112, 144, 288, 32,  64,  64),
-            inc4e=L.Inception(None, 256, 160, 320, 32, 128, 128),
-            inc5a=L.Inception(None, 256, 160, 320, 32, 128, 128),
-            inc5b=L.Inception(None, 384, 192, 384, 48, 128, 128),
-            loss3_fc=L.Linear(None, 1000),
+        super(GoogLeNet, self).__init__()
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(None, 64, 7, stride=2, pad=3)
+            self.conv2_reduce = L.Convolution2D(None, 64, 1)
+            self.conv2 = L.Convolution2D(None, 192, 3, stride=1, pad=1)
+            self.inc3a = L.Inception(None, 64, 96, 128, 16, 32, 32)
+            self.inc3b = L.Inception(None, 128, 128, 192, 32, 96, 64)
+            self.inc4a = L.Inception(None, 192, 96, 208, 16, 48, 64)
+            self.inc4b = L.Inception(None, 160, 112, 224, 24, 64, 64)
+            self.inc4c = L.Inception(None, 128, 128, 256, 24, 64, 64)
+            self.inc4d = L.Inception(None, 112, 144, 288, 32, 64, 64)
+            self.inc4e = L.Inception(None, 256, 160, 320, 32, 128, 128)
+            self.inc5a = L.Inception(None, 256, 160, 320, 32, 128, 128)
+            self.inc5b = L.Inception(None, 384, 192, 384, 48, 128, 128)
+            self.loss3_fc = L.Linear(None, 1000)
 
-            loss1_conv=L.Convolution2D(None, 128, 1),
-            loss1_fc1=L.Linear(None, 1024),
-            loss1_fc2=L.Linear(None, 1000),
+            self.loss1_conv = L.Convolution2D(None, 128, 1)
+            self.loss1_fc1 = L.Linear(None, 1024)
+            self.loss1_fc2 = L.Linear(None, 1000)
 
-            loss2_conv=L.Convolution2D(None, 128, 1),
-            loss2_fc1=L.Linear(None, 1024),
-            loss2_fc2=L.Linear(None, 1000)
-        )
+            self.loss2_conv = L.Convolution2D(None, 128, 1)
+            self.loss2_fc1 = L.Linear(None, 1024)
+            self.loss2_fc2 = L.Linear(None, 1000)
 
     def __call__(self, x, t):
         h = F.relu(self.conv1(x))

--- a/examples/imagenet/models_v2/googlenetbn.py
+++ b/examples/imagenet/models_v2/googlenetbn.py
@@ -4,47 +4,56 @@ import chainer.links as L
 
 
 class GoogLeNetBN(chainer.Chain):
-    """New GoogLeNet of BatchNormalization version
 
-       (patched for Chainer version 2).
-    """
+    """New GoogLeNet of BatchNormalization version."""
 
     insize = 224
 
     def __init__(self):
-        super(GoogLeNetBN, self).__init__(
-            conv1=L.Convolution2D(None, 64, 7, stride=2, pad=3, nobias=True),
-            norm1=L.BatchNormalization(64),
-            conv2=L.Convolution2D(None, 192, 3, pad=1, nobias=True),
-            norm2=L.BatchNormalization(192),
-            inc3a=L.InceptionBN(None, 64, 64, 64, 64, 96, 'avg', 32),
-            inc3b=L.InceptionBN(None, 64, 64, 96, 64, 96, 'avg', 64),
-            inc3c=L.InceptionBN(None, 0, 128, 160, 64, 96, 'max', stride=2),
-            inc4a=L.InceptionBN(None, 224, 64, 96, 96, 128, 'avg', 128),
-            inc4b=L.InceptionBN(None, 192, 96, 128, 96, 128, 'avg', 128),
-            inc4c=L.InceptionBN(None, 128, 128, 160, 128, 160, 'avg', 128),
-            inc4d=L.InceptionBN(None, 64, 128, 192, 160, 192, 'avg', 128),
-            inc4e=L.InceptionBN(None, 0, 128, 192, 192, 256, 'max', stride=2),
-            inc5a=L.InceptionBN(None, 352, 192, 320, 160, 224, 'avg', 128),
-            inc5b=L.InceptionBN(None, 352, 192, 320, 192, 224, 'max', 128),
-            out=L.Linear(None, 1000),
+        super(GoogLeNetBN, self).__init__()
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(
+                None, 64, 7, stride=2, pad=3, nobias=True)
+            self.norm1 = L.BatchNormalization(64)
+            self.conv2 = L.Convolution2D(None, 192, 3, pad=1, nobias=True)
+            self.norm2 = L.BatchNormalization(192)
+            self.inc3a = L.InceptionBN(
+                None, 64, 64, 64, 64, 96, 'avg', 32)
+            self.inc3b = L.InceptionBN(
+                None, 64, 64, 96, 64, 96, 'avg', 64)
+            self.inc3c = L.InceptionBN(
+                None, 0, 128, 160, 64, 96, 'max', stride=2)
+            self.inc4a = L.InceptionBN(
+                None, 224, 64, 96, 96, 128, 'avg', 128)
+            self.inc4b = L.InceptionBN(
+                None, 192, 96, 128, 96, 128, 'avg', 128)
+            self.inc4c = L.InceptionBN(
+                None, 128, 128, 160, 128, 160, 'avg', 128)
+            self.inc4d = L.InceptionBN(
+                None, 64, 128, 192, 160, 192, 'avg', 128)
+            self.inc4e = L.InceptionBN(
+                None, 0, 128, 192, 192, 256, 'max', stride=2)
+            self.inc5a = L.InceptionBN(
+                None, 352, 192, 320, 160, 224, 'avg', 128)
+            self.inc5b = L.InceptionBN(
+                None, 352, 192, 320, 192, 224, 'max', 128)
+            self.out = L.Linear(None, 1000)
 
-            conva=L.Convolution2D(None, 128, 1, nobias=True),
-            norma=L.BatchNormalization(128),
-            lina=L.Linear(None, 1024, nobias=True),
-            norma2=L.BatchNormalization(1024),
-            outa=L.Linear(None, 1000),
+            self.conva = L.Convolution2D(None, 128, 1, nobias=True)
+            self.norma = L.BatchNormalization(128)
+            self.lina = L.Linear(None, 1024, nobias=True)
+            self.norma2 = L.BatchNormalization(1024)
+            self.outa = L.Linear(None, 1000)
 
-            convb=L.Convolution2D(None, 128, 1, nobias=True),
-            normb=L.BatchNormalization(128),
-            linb=L.Linear(None, 1024, nobias=True),
-            normb2=L.BatchNormalization(1024),
-            outb=L.Linear(None, 1000),
-        )
+            self.convb = L.Convolution2D(None, 128, 1, nobias=True)
+            self.normb = L.BatchNormalization(128)
+            self.linb = L.Linear(None, 1024, nobias=True)
+            self.normb2 = L.BatchNormalization(1024)
+            self.outb = L.Linear(None, 1000)
 
     def __call__(self, x, t):
         h = F.max_pooling_2d(
-            F.relu(self.norm1(self.conv1(x))),  3, stride=2, pad=1)
+            F.relu(self.norm1(self.conv1(x))), 3, stride=2, pad=1)
         h = F.max_pooling_2d(
             F.relu(self.norm2(self.conv2(h))), 3, stride=2, pad=1)
 

--- a/examples/imagenet/models_v2/nin.py
+++ b/examples/imagenet/models_v2/nin.py
@@ -1,7 +1,6 @@
-import math
-
 import chainer
 import chainer.functions as F
+import chainer.initializers as I
 import chainer.links as L
 
 
@@ -12,17 +11,18 @@ class NIN(chainer.Chain):
     insize = 227
 
     def __init__(self):
-        w = math.sqrt(2)  # MSRA scaling
-        super(NIN, self).__init__(
-            mlpconv1=L.MLPConvolution2D(
-                None, (96, 96, 96), 11, stride=4, wscale=w),
-            mlpconv2=L.MLPConvolution2D(
-                None, (256, 256, 256), 5, pad=2, wscale=w),
-            mlpconv3=L.MLPConvolution2D(
-                None, (384, 384, 384), 3, pad=1, wscale=w),
-            mlpconv4=L.MLPConvolution2D(
-                None, (1024, 1024, 1000), 3, pad=1, wscale=w),
-        )
+        super(NIN, self).__init__()
+        conv_init = I.HeNormal()  # MSRA scaling
+
+        with self.init_scope():
+            self.mlpconv1 = L.MLPConvolution2D(
+                None, (96, 96, 96), 11, stride=4, conv_init=conv_init)
+            self.mlpconv2 = L.MLPConvolution2D(
+                None, (256, 256, 256), 5, pad=2, conv_init=conv_init)
+            self.mlpconv3 = L.MLPConvolution2D(
+                None, (384, 384, 384), 3, pad=1, conv_init=conv_init)
+            self.mlpconv4 = L.MLPConvolution2D(
+                None, (1024, 1024, 1000), 3, pad=1, conv_init=conv_init)
 
     def __call__(self, x, t):
         h = F.max_pooling_2d(F.relu(self.mlpconv1(x)), 3, stride=2)

--- a/examples/imagenet/models_v2/resnet50.py
+++ b/examples/imagenet/models_v2/resnet50.py
@@ -10,25 +10,24 @@ import chainer.links as L
 class BottleNeckA(chainer.Chain):
 
     def __init__(self, in_size, ch, out_size, stride=2):
-        super(BottleNeckA, self).__init__(
-            conv1=L.Convolution2D(in_size, ch, 1, stride, 0,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn1=L.BatchNormalization(ch),
-            conv2=L.Convolution2D(ch, ch, 3, 1, 1,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn2=L.BatchNormalization(ch),
-            conv3=L.Convolution2D(ch, out_size, 1, 1, 0,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn3=L.BatchNormalization(out_size),
+        super(BottleNeckA, self).__init__()
+        initialW = initializers.HeNormal()
 
-            conv4=L.Convolution2D(in_size, out_size, 1, stride, 0,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn4=L.BatchNormalization(out_size),
-        )
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(
+                in_size, ch, 1, stride, 0, initialW=initialW, nobias=True)
+            self.bn1 = L.BatchNormalization(ch)
+            self.conv2 = L.Convolution2D(
+                ch, ch, 3, 1, 1, initialW=initialW, nobias=True)
+            self.bn2 = L.BatchNormalization(ch)
+            self.conv3 = L.Convolution2D(
+                ch, out_size, 1, 1, 0, initialW=initialW, nobias=True)
+            self.bn3 = L.BatchNormalization(out_size)
+
+            self.conv4 = L.Convolution2D(
+                in_size, out_size, 1, stride, 0,
+                initialW=initialW, nobias=True)
+            self.bn4 = L.BatchNormalization(out_size)
 
     def __call__(self, x):
         h1 = F.relu(self.bn1(self.conv1(x)))
@@ -42,20 +41,19 @@ class BottleNeckA(chainer.Chain):
 class BottleNeckB(chainer.Chain):
 
     def __init__(self, in_size, ch):
-        super(BottleNeckB, self).__init__(
-            conv1=L.Convolution2D(in_size, ch, 1, 1, 0,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn1=L.BatchNormalization(ch),
-            conv2=L.Convolution2D(ch, ch, 3, 1, 1,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn2=L.BatchNormalization(ch),
-            conv3=L.Convolution2D(ch, in_size, 1, 1, 0,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn3=L.BatchNormalization(in_size),
-        )
+        super(BottleNeckB, self).__init__()
+        initialW = initializers.HeNormal()
+
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(
+                in_size, ch, 1, 1, 0, initialW=initialW, nobias=True)
+            self.bn1 = L.BatchNormalization(ch)
+            self.conv2 = L.Convolution2D(
+                ch, ch, 3, 1, 1, initialW=initialW, nobias=True)
+            self.bn2 = L.BatchNormalization(ch)
+            self.conv3 = L.Convolution2D(
+                ch, in_size, 1, 1, 0, initialW=initialW, nobias=True)
+            self.bn3 = L.BatchNormalization(in_size)
 
     def __call__(self, x):
         h = F.relu(self.bn1(self.conv1(x)))
@@ -65,23 +63,17 @@ class BottleNeckB(chainer.Chain):
         return F.relu(h + x)
 
 
-class Block(chainer.Chain):
+class Block(chainer.ChainList):
 
     def __init__(self, layer, in_size, ch, out_size, stride=2):
         super(Block, self).__init__()
-        links = [('a', BottleNeckA(in_size, ch, out_size, stride))]
+        self.add_link(BottleNeckA(in_size, ch, out_size, stride))
         for i in range(layer - 1):
-            links += [('b{}'.format(i + 1), BottleNeckB(out_size, ch))]
-
-        for l in links:
-            self.add_link(*l)
-        self.forward = links
+            self.add_link(BottleNeckB(out_size, ch))
 
     def __call__(self, x):
-        for name, _ in sorted(self.forward):
-            f = getattr(self, name)
+        for f in self.children():
             x = f(x)
-
         return x
 
 
@@ -90,24 +82,18 @@ class ResNet50(chainer.Chain):
     insize = 224
 
     def __init__(self):
-        super(ResNet50, self).__init__(
-            conv1=L.Convolution2D(3, 64, 7, 2, 3,
-                                  initialW=initializers.HeNormal(),
-                                  nobias=True),
-            bn1=L.BatchNormalization(64),
-            res2=Block(3, 64, 64, 256, 1),
-            res3=Block(4, 256, 128, 512),
-            res4=Block(6, 512, 256, 1024),
-            res5=Block(3, 1024, 512, 2048),
-            fc=L.Linear(2048, 1000),
-        )
-
-    def clear(self):
-        self.loss = None
-        self.accuracy = None
+        super(ResNet50, self).__init__()
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(
+                3, 64, 7, 2, 3, initialW=initializers.HeNormal())
+            self.bn1 = L.BatchNormalization(64)
+            self.res2 = Block(3, 64, 64, 256, 1)
+            self.res3 = Block(4, 256, 128, 512)
+            self.res4 = Block(6, 512, 256, 1024)
+            self.res5 = Block(3, 1024, 512, 2048)
+            self.fc = L.Linear(2048, 1000)
 
     def __call__(self, x, t):
-        self.clear()
         h = self.bn1(self.conv1(x))
         h = F.max_pooling_2d(F.relu(h), 3, stride=2)
         h = self.res2(h)


### PR DESCRIPTION
Actually models other than NIN work correctly with the current code, but NIN model raises the error below with Chainer v2.

```
$ cd chainermn/examples/imagenet/models_v2
$ python -c 'from nin import NIN; model = NIN()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/shunta/Codes/chainermn/examples/imagenet/models_v2/nin.py", line 18, in __init__
    None, (96, 96, 96), 11, stride=4, wscale=w),
  File "/Users/shunta/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer/links/connection/mlp_convolution_2d.py", line 69, in __init__
    argument.check_unexpected_kwargs(kwargs, wscale=msg)
  File "/Users/shunta/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer/utils/argument.py", line 4, in check_unexpected_kwargs
    raise ValueError(message)
ValueError: wscale is not supported anymore. Use conv_init and bias_init argument to change the scale of initial parameters.
```

This PR fixes this and also update all other models for V2 style.