### PR TITLE
Add MultiNodeBatchNormalization

### DIFF
--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -1,5 +1,4 @@
 import chainer
-from chainer import configuration
 from chainer import cuda
 from chainer import function
 import chainer.utils
@@ -84,7 +83,7 @@ class MultiNodeBatchNormalizationFunction(function.Function):
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         x, gamma, beta = inputs[:3]
-        if configuration.config.train:
+        if chainer.configuration.config.train:
             if self.running_mean is None:
                 self.running_mean = xp.zeros_like(gamma)
                 self.running_var = xp.zeros_like(gamma)
@@ -113,7 +112,7 @@ class MultiNodeBatchNormalizationFunction(function.Function):
 
         cudnn_updated_running_stats = False
 
-        if configuration.config.train:
+        if chainer.configuration.config.train:
             axis = (0,) + tuple(range(head_ndim, x.ndim))
 
             mpi_comm = self.comm.mpi_comm
@@ -150,7 +149,7 @@ class MultiNodeBatchNormalizationFunction(function.Function):
                 'bn_fwd')(x, mean[expander], self.std[expander], gamma,
                           beta)
 
-        if configuration.config.train and (not cudnn_updated_running_stats):
+        if chainer.configuration.config.train and (not cudnn_updated_running_stats):
             # Note: If in training mode, the cuDNN forward training function
             # will do this for us, so
             # only run following code if cuDNN was not used.
@@ -193,7 +192,7 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             return gx, ggamma, gbeta, gmean, gvar
 
         # Note: If length of inputs is not 5, we must be in train mode.
-        assert configuration.config.train
+        assert chainer.configuration.config.train
 
         # It is wrong to multiply m by mpi_comm.size
         # (instead of multiplying 1/size to gbeta, ggamma)

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -119,7 +119,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
             x.mean(axis=axis, out=tmp[:gamma.size])
             xp.square(x).mean(axis=axis, out=tmp[gamma.size:])
-            chainer.cuda.Stream.null.synchronize()
+            if xp is not numpy:
+                chainer.cuda.Stream.null.synchronize()
             mpi_comm.Allreduce(
                 self.mpi4py_module.IN_PLACE,
                 self.memory_utility_module.array_to_buffer_object(tmp))
@@ -199,7 +200,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
         tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
         gy.sum(axis=axis, out=tmp[:gamma.size])
         (gy * self.x_hat).sum(axis=axis, out=tmp[gamma.size:])
-        chainer.cuda.Stream.null.synchronize()
+        if xp is not numpy:
+            chainer.cuda.Stream.null.synchronize()
         mpi_comm.Allreduce(
             self.mpi4py_module.IN_PLACE,
             self.memory_utility_module.array_to_buffer_object(tmp))

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -1,14 +1,10 @@
-import cffi
 import chainer
-import numpy
 from chainer import configuration
 from chainer import cuda
 from chainer import function
+import chainer.utils
 from chainer.utils import type_check
-
-import mpi4py.MPI
-
-ffi = cffi.FFI()
+import numpy
 
 
 if cuda.cudnn_enabled:
@@ -34,6 +30,8 @@ def _xhat(x, mean, std, expander):
 class MultiNodeBatchNormalizationFunction(function.Function):
 
     def __init__(self, comm, eps=2e-5, mean=None, var=None, decay=0.9):
+        chainer.utils.experimental('chainermn.functions.MultiNodeBatchNormalizationFunction')
+
         self.comm = comm
         self.running_mean = mean
         self.running_var = var

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -50,10 +50,10 @@ class MultiNodeBatchNormalizationFunction(function.Function):
         self.decay = decay
 
         # We need to delay importing MPI4py (and momdules that import MPI4py)
-        from mpi4py import MPI as mpi4py_module
         import chainermn.communicators._memory_utility as memory_utility_module
-        self.mpi4py_module = mpi4py_module
+        from mpi4py import MPI as mpi4py_module
         self.memory_utility_module = memory_utility_module
+        self.mpi4py_module = mpi4py_module
 
     def check_type_forward(self, in_types):
         n_in = type_check.eval(in_types.size())

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -154,7 +154,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
                 'bn_fwd')(x, mean[expander], self.std[expander], gamma,
                           beta)
 
-        if chainer.configuration.config.train and (not cudnn_updated_running_stats):
+        if chainer.configuration.config.train and \
+                (not cudnn_updated_running_stats):
             # Note: If in training mode, the cuDNN forward training function
             # will do this for us, so
             # only run following code if cuDNN was not used.

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -30,7 +30,8 @@ def _xhat(x, mean, std, expander):
 class MultiNodeBatchNormalizationFunction(function.Function):
 
     def __init__(self, comm, eps=2e-5, mean=None, var=None, decay=0.9):
-        chainer.utils.experimental('chainermn.functions.MultiNodeBatchNormalizationFunction')
+        chainer.utils.experimental(
+            'chainermn.functions.MultiNodeBatchNormalizationFunction')
 
         self.comm = comm
         self.running_mean = mean

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -1,0 +1,227 @@
+import cffi
+import chainer
+import numpy
+from chainer import configuration
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+import mpi4py.MPI
+
+ffi = cffi.FFI()
+
+
+if cuda.cudnn_enabled:
+    cudnn = cuda.cudnn
+    libcudnn = cudnn.cudnn
+
+
+def _as4darray(arr):
+    if arr.ndim == 0:
+        return arr.reshape(1, 1, 1, 1)
+    elif arr.ndim == 4:
+        return arr
+    else:
+        return arr.reshape(arr.shape[0], -1, 1, 1)
+
+
+def _xhat(x, mean, std, expander):
+    x_mu = x - mean[expander]
+    x_mu /= std[expander]
+    return x_mu
+
+
+class MultiNodeBatchNormalizationFunction(function.Function):
+
+    def __init__(self, comm, eps=2e-5, mean=None, var=None, decay=0.9):
+        self.comm = comm
+        self.running_mean = mean
+        self.running_var = var
+
+        # Note: cuDNN v5 requires that eps be greater than 1e-5. Otherwise, an
+        # error will occur.
+        # See CUDNN_BN_MIN_EPSILON value in cudnn.h to verify minimum allowable
+        # value.
+        self.eps = eps
+        if chainer.should_use_cudnn('>=auto'):
+            if eps < 1e-5:
+                msg = 'cuDNN does not allow an eps value less than 1e-5.'
+                raise RuntimeError(msg)
+        self.mean_cache = None
+        self.decay = decay
+
+        # We need to delay importing MPI4py (and momdules that import MPI4py)
+        from mpi4py import MPI as mpi4py_module
+        import chainermn.communicators._memory_utility as memory_utility_module
+        self.mpi4py_module = mpi4py_module
+        self.memory_utility_module = memory_utility_module
+
+    def check_type_forward(self, in_types):
+        n_in = type_check.eval(in_types.size())
+        if n_in != 3 and n_in != 5:
+            raise type_check.InvalidType(
+                '%s or %s' % (in_types.size() == 3, in_types.size() == 5),
+                '%s == %s' % (in_types.size(), n_in))
+        x_type, gamma_type, beta_type = in_types[:3]
+        M = type_check.eval(gamma_type.ndim)
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim >= gamma_type.ndim + 1,
+            x_type.shape[1:1 + M] == gamma_type.shape,
+            # TODO(beam2d): Check shape
+            gamma_type.dtype == x_type.dtype,
+            beta_type.dtype == x_type.dtype,
+            gamma_type.shape == beta_type.shape,
+        )
+        if len(in_types) == 5:
+            mean_type, var_type = in_types[3:]
+            type_check.expect(
+                mean_type.dtype == x_type.dtype,
+                mean_type.shape == gamma_type.shape,
+                var_type.dtype == x_type.dtype,
+                var_type.shape == gamma_type.shape,
+            )
+
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        x, gamma, beta = inputs[:3]
+        if configuration.config.train:
+            if self.running_mean is None:
+                self.running_mean = xp.zeros_like(gamma)
+                self.running_var = xp.zeros_like(gamma)
+            else:
+                self.running_mean = xp.array(self.running_mean)
+                self.running_var = xp.array(self.running_var)
+        elif len(inputs) == 5:
+            self.fixed_mean = inputs[3]
+            self.fixed_var = inputs[4]
+
+        head_ndim = gamma.ndim + 1
+        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
+        gamma = gamma[expander]
+        beta = beta[expander]
+
+        # cuDNN only supports these tensor dimensions because they are
+        # the most commonly used. If there is a need to support other
+        # dimensions with cuDNN, we could consider reshaping the input
+        # into a 2-dim array with channels as second dim and m=<product
+        # of all dimensions except the 2nd dimension> as the first
+        # dimension.
+        cudnn_dim_ok = x.ndim == 2 or (x.ndim == 4 and head_ndim == 2)
+        # TODO(bkvogel): Check for float16 support again in next cuDNN version.
+        # cuDNN v5 batch normalization does not seem to support float16.
+        self._can_use_cudnn = cudnn_dim_ok and x[0].dtype != numpy.float16
+
+        cudnn_updated_running_stats = False
+
+        if configuration.config.train:
+            axis = (0,) + tuple(range(head_ndim, x.ndim))
+
+            mpi_comm = self.comm.mpi_comm
+            tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
+            x.mean(axis=axis, out=tmp[:gamma.size])
+            xp.square(x).mean(axis=axis, out=tmp[gamma.size:])
+            chainer.cuda.Stream.null.synchronize()
+            mpi_comm.Allreduce(
+                self.mpi4py_module.IN_PLACE,
+                self.memory_utility_module.array_to_buffer_object(tmp))
+            tmp *= 1.0 / mpi_comm.size
+
+            mean = tmp[:gamma.size]
+            sqmean = tmp[gamma.size:]
+            var = sqmean - xp.square(mean)
+
+            var += self.eps
+        else:
+            mean = self.fixed_mean
+            var = self.fixed_var + self.eps
+        self.std = xp.sqrt(var, dtype=var.dtype)
+        if xp is numpy:
+            self.x_hat = _xhat(x, mean, self.std, expander)
+            y = gamma * self.x_hat
+            y += beta
+        else:
+            self.x_hat, y = cuda.elementwise(
+                'T x, T mean, T std, T gamma, T beta', 'T x_hat, T y',
+                '''
+                x_hat = (x - mean) / std;
+                y = gamma * x_hat + beta;
+                ''',
+                'bn_fwd')(x, mean[expander], self.std[expander], gamma,
+                          beta)
+
+        if configuration.config.train and (not cudnn_updated_running_stats):
+            # Note: If in training mode, the cuDNN forward training function
+            # will do this for us, so
+            # only run following code if cuDNN was not used.
+            # Update running statistics:
+            m = x.size // gamma.size
+            adjust = m / max(m - 1., 1.)  # unbiased estimation
+            self.running_mean *= self.decay
+            temp_ar = xp.array(mean)
+            temp_ar *= (1 - self.decay)
+            self.running_mean += temp_ar
+            del temp_ar
+            self.running_var *= self.decay
+            temp_ar = xp.array(var)
+            temp_ar *= (1 - self.decay) * adjust
+            self.running_var += temp_ar
+            del temp_ar
+        return y,
+
+    def backward(self, inputs, grad_outputs):
+        x, gamma = inputs[:2]
+        gy = grad_outputs[0]
+        head_ndim = gamma.ndim + 1
+        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
+        m = gamma.dtype.type(x.size // gamma.size)
+        axis = (0,) + tuple(range(head_ndim, x.ndim))
+        xp = cuda.get_array_module(x)
+        if len(inputs) == 5:
+            # This case is unlikely to be used in practice and so does not
+            # need to be optimized for performance.
+            mean = inputs[3]
+            var = inputs[4]
+            std = xp.sqrt(var, dtype=var.dtype)
+            gs = gamma / std
+            gbeta = gy.sum(axis=axis)
+            x_hat = _xhat(x, mean, std, expander)
+            ggamma = (gy * x_hat).sum(axis=axis)
+            gmean = -gs * gbeta
+            gvar = -0.5 * gamma / var * ggamma
+            gx = gs[expander] * gy
+            return gx, ggamma, gbeta, gmean, gvar
+
+        # Note: If length of inputs is not 5, we must be in train mode.
+        assert configuration.config.train
+
+        # It is wrong to multiply m by mpi_comm.size
+        # (instead of multiplying 1/size to gbeta, ggamma)
+        mpi_comm = self.comm.mpi_comm
+        tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
+        gy.sum(axis=axis, out=tmp[:gamma.size])
+        (gy * self.x_hat).sum(axis=axis, out=tmp[gamma.size:])
+        chainer.cuda.Stream.null.synchronize()
+        mpi_comm.Allreduce(
+            self.mpi4py_module.IN_PLACE,
+            self.memory_utility_module.array_to_buffer_object(tmp))
+        tmp *= 1.0 / mpi_comm.size
+        gbeta = tmp[:gamma.size]
+        ggamma = tmp[gamma.size:]
+
+        if xp is numpy:
+            gx = (gamma / self.std)[expander] * (
+                gy - (self.x_hat * ggamma[expander] + gbeta[expander]) / m)
+        else:
+            inv_m = numpy.float32(1) / m
+            gx = cuda.elementwise(
+                'T gy, T x_hat, T gamma, T std, T ggamma, T gbeta, \
+                T inv_m',
+                'T gx',
+                'gx = (gamma / std) * (gy - (x_hat * ggamma + gbeta) * \
+                inv_m)',
+                'bn_bwd')(gy, self.x_hat, gamma[expander],
+                          self.std[expander], ggamma[expander],
+                          gbeta[expander], inv_m)
+
+        return gx, ggamma, gbeta

--- a/chainermn/links/__init__.py
+++ b/chainermn/links/__init__.py
@@ -1,0 +1,1 @@
+from chainermn.links.batch_normalization import MultiNodeBatchNormalization  # NOQA

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -1,0 +1,87 @@
+import numpy
+
+from chainer import configuration
+from chainer import cuda
+from chainer import initializers
+from chainer import link
+from chainer import variable
+from chainer.functions.normalization import batch_normalization
+
+from chainermn.functions.batch_normalization import \
+    MultiNodeBatchNormalizationFunction
+
+
+class MultiNodeBatchNormalization(link.Link):
+
+    def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=numpy.float32,
+                 use_gamma=True, use_beta=True,
+                 initial_gamma=None, initial_beta=None):
+        super(MultiNodeBatchNormalization, self).__init__()
+        self.comm = comm
+        self.avg_mean = numpy.zeros(size, dtype=dtype)
+        self.register_persistent('avg_mean')
+        self.avg_var = numpy.zeros(size, dtype=dtype)
+        self.register_persistent('avg_var')
+        self.N = 0
+        self.register_persistent('N')
+        self.decay = decay
+        self.eps = eps
+
+        with self.init_scope():
+            if use_gamma:
+                if initial_gamma is None:
+                    initial_gamma = 1
+                initial_gamma = initializers._get_initializer(initial_gamma)
+                initial_gamma.dtype = dtype
+                self.gamma = variable.Parameter(initial_gamma, size)
+            if use_beta:
+                if initial_beta is None:
+                    initial_beta = 0
+                initial_beta = initializers._get_initializer(initial_beta)
+                initial_beta.dtype = dtype
+                self.beta = variable.Parameter(initial_beta, size)
+
+    def __call__(self, x, finetune=False):
+        if hasattr(self, 'gamma'):
+            gamma = self.gamma
+        else:
+            with cuda.get_device_from_id(self._device_id):
+                gamma = variable.Variable(self.xp.ones(
+                    self.avg_mean.shape, dtype=x.dtype))
+        if hasattr(self, 'beta'):
+            beta = self.beta
+        else:
+            with cuda.get_device_from_id(self._device_id):
+                beta = variable.Variable(self.xp.zeros(
+                    self.avg_mean.shape, dtype=x.dtype))
+
+        if configuration.config.train:
+            if finetune:
+                self.N += 1
+                decay = 1. - 1. / self.N
+            else:
+                decay = self.decay
+
+            func = MultiNodeBatchNormalizationFunction(
+                self.comm, self.eps, self.avg_mean, self.avg_var, decay)
+            ret = func(x, gamma, beta)
+
+            self.avg_mean[:] = func.running_mean
+            self.avg_var[:] = func.running_var
+        else:
+            # Use running average statistics or fine-tuned statistics.
+            mean = variable.Variable(self.avg_mean)
+            var = variable.Variable(self.avg_var)
+            ret = batch_normalization.fixed_batch_normalization(
+                x, gamma, beta, mean, var, self.eps)
+        return ret
+
+    def start_finetuning(self):
+        """Resets the population count for collecting population statistics.
+
+        This method can be skipped if it is the first time to use the
+        fine-tuning mode. Otherwise, this method should be called before
+        starting the fine-tuning mode again.
+
+        """
+        self.N = 0

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -1,5 +1,4 @@
 import chainer
-from chainer import configuration
 from chainer import cuda
 from chainer.functions.normalization import batch_normalization
 from chainer import initializers
@@ -91,7 +90,7 @@ class MultiNodeBatchNormalization(link.Link):
                 beta = variable.Variable(self.xp.zeros(
                     self.avg_mean.shape, dtype=x.dtype))
 
-        if configuration.config.train:
+        if chainer.configuration.config.train:
             if finetune:
                 self.N += 1
                 decay = 1. - 1. / self.N

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -1,11 +1,11 @@
-import numpy
-
+import chainer.utils
 from chainer import configuration
 from chainer import cuda
 from chainer import initializers
 from chainer import link
 from chainer import variable
 from chainer.functions.normalization import batch_normalization
+import numpy
 
 from chainermn.functions.batch_normalization import \
     MultiNodeBatchNormalizationFunction
@@ -16,6 +16,8 @@ class MultiNodeBatchNormalization(link.Link):
     def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None):
+        chainer.utils.experimental('chainermn.links.MultiNodeBatchNormalization')
+
         super(MultiNodeBatchNormalization, self).__init__()
         self.comm = comm
         self.avg_mean = numpy.zeros(size, dtype=dtype)

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -13,6 +13,31 @@ from chainermn.functions.batch_normalization import \
 
 class MultiNodeBatchNormalization(link.Link):
 
+    """Batch normalization layer that can use the whole batch stats.
+
+    When using chainer.link.BatchNormalization, batch mean and std are
+    computed independently for the local batch in each worker. When local
+    batch size is too small, training is unstable due to unreliable batch
+    stats.
+
+    In contrast, when using this MultiNodeBatchNormalization, workers
+    communicate to conduct 'correct' batch normalization (e.g., obtaining
+    mean and std for the whole global batch).
+
+    Args:
+        size (int or tuple of ints): Size (or shape) of channel
+            dimensions.
+        comm (ChainerMN communicator): communicator to share
+            the batch stats.
+        decay (float): Decay rate of moving average. It is used on training.
+        eps (float): Epsilon value for numerical stability.
+        dtype (numpy.dtype): Type to use in computing.
+        use_gamma (bool): If ``True``, use scaling parameter. Otherwise, use
+            unit(1) which makes no effect.
+        use_beta (bool): If ``True``, use shifting parameter. Otherwise, use
+            unit(0) which makes no effect.
+    """
+
     def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None):

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import configuration
 from chainer import cuda
 from chainer.functions.normalization import batch_normalization
@@ -43,6 +44,11 @@ class MultiNodeBatchNormalization(link.Link):
                  initial_gamma=None, initial_beta=None):
         chainer.utils.experimental(
             'chainermn.links.MultiNodeBatchNormalization')
+
+        if chainer.__version__.startswith('1.'):
+            raise RuntimeError(
+                'MultiNodeBatchNormalization works only with '
+                'chainer >= 2.0.0.')
 
         super(MultiNodeBatchNormalization, self).__init__()
         self.comm = comm

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -1,10 +1,10 @@
-import chainer.utils
 from chainer import configuration
 from chainer import cuda
+from chainer.functions.normalization import batch_normalization
 from chainer import initializers
 from chainer import link
+import chainer.utils
 from chainer import variable
-from chainer.functions.normalization import batch_normalization
 import numpy
 
 from chainermn.functions.batch_normalization import \

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -16,7 +16,8 @@ class MultiNodeBatchNormalization(link.Link):
     def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=numpy.float32,
                  use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None):
-        chainer.utils.experimental('chainermn.links.MultiNodeBatchNormalization')
+        chainer.utils.experimental(
+            'chainermn.links.MultiNodeBatchNormalization')
 
         super(MultiNodeBatchNormalization, self).__init__()
         self.comm = comm

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -25,6 +25,8 @@ class MultiNodeBatchNormalization(link.Link):
     communicate to conduct 'correct' batch normalization (e.g., obtaining
     mean and std for the whole global batch).
 
+    This link works only with Chainer >= 2.0.0.
+
     Args:
         size (int or tuple of ints): Size (or shape) of channel
             dimensions.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -15,6 +15,7 @@ Links
 
 .. autoclass:: MultiNodeChainList
     :members: add_link
+.. autoclass:: chainermn.links.MultiNodeBatchNormalization
 
 
 Optimizers and Evaluators

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -1,0 +1,113 @@
+import unittest
+
+import mpi4py.MPI
+import numpy as np
+
+from chainermn.communicators.naive_communicator import NaiveCommunicator
+
+import copy
+import nose.plugins.skip
+import unittest
+
+import chainer
+import chainer.testing
+import chainer.testing.attr
+import numpy
+
+import chainermn
+import chainermn.links
+
+
+class ModelNormalBN(chainer.Chain):
+    def __init__(self, n_in=3, n_units=3, n_out=2):
+        super(ModelNormalBN, self).__init__(
+            l1=chainer.links.Linear(n_in, n_units, nobias=True),
+            bn1=chainer.links.BatchNormalization(n_units),
+            l2=chainer.links.Linear(n_in, n_units, nobias=True),
+            bn2=chainer.links.BatchNormalization(n_units),
+            l3=chainer.links.Linear(n_in, n_out),
+        )
+        self.train = True
+
+    def __call__(self, x):
+        h = chainer.functions.relu(self.bn1(self.l1(x)))
+        h = chainer.functions.relu(self.bn2(self.l2(h)))
+        return self.l3(h)
+
+
+class ModelDistributedBN(chainer.Chain):
+    def __init__(self, comm, n_in=3, n_units=3, n_out=2):
+        super(ModelDistributedBN, self).__init__(
+            l1=chainer.links.Linear(n_in, n_units, nobias=True),
+            bn1=chainermn.links.MultiNodeBatchNormalization(n_units, comm),
+            l2=chainer.links.Linear(n_in, n_units, nobias=True),
+            bn2=chainermn.links.MultiNodeBatchNormalization(n_units, comm),
+            l3=chainer.links.Linear(n_in, n_out),
+        )
+        self.train = True
+
+    def __call__(self, x):
+        h = chainer.functions.relu(self.bn1(self.l1(x)))
+        h = chainer.functions.relu(self.bn2(self.l2(h)))
+        return self.l3(h)
+
+
+class TestDataset(unittest.TestCase):
+
+    def setUp(self):
+        self.mpi_comm = mpi4py.MPI.COMM_WORLD
+        self.communicator = NaiveCommunicator(self.mpi_comm)
+
+    def test_multi_node_bn(self):
+        comm = self.communicator
+
+        local_batchsize = 10
+        global_batchsize = 10 * comm.size
+        ndim = 3
+        np.random.seed(71)
+        x = np.random.random((global_batchsize, ndim)).astype(np.float32)
+        y = np.random.randint(0, 1, size=global_batchsize, dtype=np.int32)
+        x_local = comm.mpi_comm.scatter(x.reshape(comm.size, local_batchsize, ndim))
+        y_local = comm.mpi_comm.scatter(y.reshape(comm.size, local_batchsize))
+        print(x.shape, y.shape, x_local.shape, y_local.shape)
+
+        m1 = chainer.links.Classifier(ModelNormalBN())       # Single Normal
+        m2 = chainer.links.Classifier(ModelNormalBN())       # Distributed Normal
+        m3 = chainer.links.Classifier(ModelDistributedBN(comm))  # Distributed BN
+        m4 = chainer.links.Classifier(ModelDistributedBN(comm))  # Sequential Normal
+        m2.copyparams(m1)
+        m3.copyparams(m1)
+        m4.copyparams(m1)
+
+        l1 = m1(x, y)
+        m1.cleargrads()
+        l1.backward()
+
+        l2 = m2(x_local, y_local)
+        m2.cleargrads()
+        l2.backward()
+        comm.allreduce_grad(m2)
+
+        l3 = m3(x, y)
+        m3.cleargrads()
+        l3.backward()
+
+        l4 = m4(x_local, y_local)
+        m4.cleargrads()
+        l4.backward()
+        comm.allreduce_grad(m4)
+
+        if comm.rank == 0:
+            for p1, p2, p3, p4 in zip(
+                    sorted(m1.namedparams()),
+                    sorted(m2.namedparams()),
+                    sorted(m3.namedparams()),
+                    sorted(m4.namedparams())):
+                name = p1[0]
+                assert(p2[0] == name)
+                assert(p3[0] == name)
+                assert(p4[0] == name)
+
+                # TODO: check p1[1].grad != p2[1].grad (to confirm that this test is valid)
+                chainer.testing.assert_allclose(p1[1].grad, p3[1].grad)
+                chainer.testing.assert_allclose(p1[1].grad, p4[1].grad)

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -3,6 +3,7 @@ import chainer.testing
 import chainer.testing.attr
 import chainer.utils
 import mpi4py.MPI
+import nose.plugins.skip
 import numpy
 import unittest
 
@@ -51,7 +52,15 @@ class TestMultiNodeBatchNormalization(unittest.TestCase):
         self.mpi_comm = mpi4py.MPI.COMM_WORLD
         self.communicator = NaiveCommunicator(self.mpi_comm)
 
+    def test_version_check(self):
+        if chainer.__version__.startswith('1.'):
+            with self.assertRaises(RuntimeError):
+                chainermn.links.MultiNodeBatchNormalization(3, self.communicator)
+
     def test_multi_node_bn(self):
+        if chainer.__version__.startswith('1.'):
+            raise nose.plugins.skip.SkipTest()
+
         comm = self.communicator
 
         local_batchsize = 10

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -63,6 +63,33 @@ class TestMultiNodeBatchNormalization(unittest.TestCase):
                 3, self.communicator)
 
     def test_multi_node_bn(self):
+        """Tests correctness of MultiNodeBatchNormalization.
+
+        This test verifies MultiNodeBatchNormalization by comparing
+        the following four configurations.
+        (1) Single worker, normal BatchNormalization
+        (2) Multiple workers, normal BatchNormalization
+        (3) Single worker, MultiNodeBatchNormalization
+        (4) Multiple workers, MultiNodeBatchNormalization
+
+        Single worker: only using the result of worker 0, which uses the whole
+            batch.
+        Multiple workers: Each worker uses the 1/n part of the whole batch,
+            where n is the number of nodes, and gradient is aggregated.
+
+        This test conducts the forward and backward computation once for the
+        deterministic model parameters and an input batch, and checks the
+        gradients of parameters.
+
+        The purpose of MultiNodeBatchNormalization is to make the results of
+        (4) to be exactly same as (1). Therefore, the essential part is to
+        check that the results of (1) and (4) are the same. The results of (3)
+        should also be also same as them. In contrast, the results of (2) is
+        not necessarily always same as them, and we can expect that it is
+        almost always different. Therefore, we also check that the results of
+        (2) is different from them, to see that this test working correctly.
+        """
+
         if chainer.__version__.startswith('1.'):
             raise nose.plugins.skip.SkipTest()
 

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -1,6 +1,7 @@
 import chainer
 import chainer.testing
 import chainer.testing.attr
+import chainer.utils
 import mpi4py.MPI
 import numpy
 import unittest
@@ -110,5 +111,13 @@ class TestDataset(unittest.TestCase):
                 chainer.testing.assert_allclose(p1[1].grad, p3[1].grad)
                 chainer.testing.assert_allclose(p1[1].grad, p4[1].grad)
 
-                # TODO: check p1[1].grad != p2[1].grad
-                # (to confirm that this test is valid)
+                # This is to see that this test is valid.
+                self.assert_not_allclose(p1[1].grad, p2[1].grad)
+
+    def assert_not_allclose(self, x, y, atol=1e-5, rtol=1e-4, verbose=True):
+        x = chainer.cuda.to_cpu(chainer.utils.force_array(x))
+        y = chainer.cuda.to_cpu(chainer.utils.force_array(y))
+
+        with self.assertRaises(AssertionError):
+            numpy.testing.assert_allclose(
+                x, y, atol=atol, rtol=rtol, verbose=verbose)

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -45,7 +45,7 @@ class ModelDistributedBN(chainer.Chain):
         return self.l3(h)
 
 
-class TestDataset(unittest.TestCase):
+class TestMultiNodeBatchNormalization(unittest.TestCase):
 
     def setUp(self):
         self.mpi_comm = mpi4py.MPI.COMM_WORLD

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -55,7 +55,12 @@ class TestMultiNodeBatchNormalization(unittest.TestCase):
     def test_version_check(self):
         if chainer.__version__.startswith('1.'):
             with self.assertRaises(RuntimeError):
-                chainermn.links.MultiNodeBatchNormalization(3, self.communicator)
+                chainermn.links.MultiNodeBatchNormalization(
+                    3, self.communicator)
+        else:
+            # Expecting no exceptions
+            chainermn.links.MultiNodeBatchNormalization(
+                3, self.communicator)
 
     def test_multi_node_bn(self):
         if chainer.__version__.startswith('1.'):

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -153,7 +153,8 @@ class TestMultiNodeBatchNormalization(unittest.TestCase):
                 chainer.testing.assert_allclose(p1[1].grad, p4[1].grad)
 
                 # This is to see that this test is valid.
-                self.assert_not_allclose(p1[1].grad, p2[1].grad)
+                if comm.size >= 2:
+                    self.assert_not_allclose(p1[1].grad, p2[1].grad)
 
     def assert_not_allclose(self, x, y, atol=1e-5, rtol=1e-4, verbose=True):
         x = chainer.cuda.to_cpu(chainer.utils.force_array(x))


### PR DESCRIPTION
This PR adds a new link `MultiNodeBatchNormalization`. When using `chainer.link.BatchNormalization`, batch mean and std are computed independently for the local batch in each worker. In contrast, when using this `MultiNodeBatchNormalization`, workers communicate to conduct 'correct' batch normalization (e.g., obtaining mean and std for the whole global batch).

## TODO
* [x] Documents
* [x] Ignore Chainer v1?
