### PR TITLE
Reduce the number of procs of MPI test for robust CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
-  #- if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
   - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' || exit $?; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
-  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   # - cd tests
   # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
-  - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+    # - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   # - cd tests
   # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
-  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
+  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   # - cd tests
   # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ os:
   - linux
 
 python:
-  # - "2.7"
+  - "2.7"
   - "3.5.1"
 
 env:
-  #- MPI="mpich-3.0.4"    CHAINER_VER="1.24"
-  #- MPI="mpich-3.0.4"    CHAINER_VER="2"
-  #- MPI="mpich-3.2"      CHAINER_VER="1.24"
-  #- MPI="mpich-3.2"      CHAINER_VER="2"
+  - MPI="mpich-3.0.4"    CHAINER_VER="1.24"
+  - MPI="mpich-3.0.4"    CHAINER_VER="2"
+  - MPI="mpich-3.2"      CHAINER_VER="1.24"
+  - MPI="mpich-3.2"      CHAINER_VER="2"
   - MPI="openmpi-1.6.5"  CHAINER_VER="1.24"
   - MPI="openmpi-1.6.5"  CHAINER_VER="2"
   - MPI="openmpi-1.10.3" CHAINER_VER="1.24"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,7 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
-  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
-  # - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ os:
   - linux
 
 python:
-  - "2.7"
+  # - "2.7"
   - "3.5.1"
 
 env:
-  - MPI="mpich-3.0.4"    CHAINER_VER="1.24"
-  - MPI="mpich-3.0.4"    CHAINER_VER="2"
-  - MPI="mpich-3.2"      CHAINER_VER="1.24"
-  - MPI="mpich-3.2"      CHAINER_VER="2"
+  #- MPI="mpich-3.0.4"    CHAINER_VER="1.24"
+  #- MPI="mpich-3.0.4"    CHAINER_VER="2"
+  #- MPI="mpich-3.2"      CHAINER_VER="1.24"
+  #- MPI="mpich-3.2"      CHAINER_VER="2"
   - MPI="openmpi-1.6.5"  CHAINER_VER="1.24"
   - MPI="openmpi-1.6.5"  CHAINER_VER="2"
   - MPI="openmpi-1.10.3" CHAINER_VER="1.24"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
-  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' ${MPIEXEC} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   # - cd tests
   # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
-  - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
-  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  #- if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
+  - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' || exit $?; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
-  - (for NP in 1 2 3; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec -n ${NP} nosetests -v -a '!nccl,!gpu,!slow' || exit $?; done)
+  - (for NP in 1 2 3; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' ${MPIEXEC} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   # - cd tests
   # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,8 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - if mpiexec --version | grep -q OpenRTE; then NOBIND="--bind-to none"; else NOBIND= ; fi
-  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
-    # - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
-  # - cd tests
-  # - PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' nosetests -a '!gpu,!slow' --with-doctest chainer_tests
+  - (for NP in 1 2; do for T in $(find tests -name "test_*.py") ; do mpiexec -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
+  # - (for NP in 1 2 4; do for T in $(find tests -name "test_*.py") ; do PYTHONWARNINGS='ignore::FutureWarning,module::DeprecationWarning' mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' $T || exit $?; done; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;
     fi


### PR DESCRIPTION
Currently, CI on Travis CI often fails because of deadlocks in 3-process test_mnist.

Although I don't find the exact reason of the deadlock, tests with up to 2 processes
does not suffer from the deadlock issue.

This PR changes the number of processes in the MPI tests (1,2,3) to two processes in `.travis.yml`.

Also, this PR changes to invoke `nosetests` command for each `test_*.py` files so it can avoid deadlocks.
