### PR TITLE
Fix the way to import cudnn

### DIFF
--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -11,7 +11,10 @@ import numpy
 
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn
-    libcudnn = cudnn.cudnn
+    try:
+        libcudnn = cudnn.cudnn
+    except Exception:
+        libcudnn = cudnn.py_cudnn
 
 
 def _as4darray(arr):

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -10,11 +10,8 @@ import numpy
 
 
 if cuda.cudnn_enabled:
-    cudnn = cuda.cudnn
-    try:
-        libcudnn = cudnn.cudnn
-    except Exception:
-        libcudnn = cudnn.py_cudnn
+    from cupy.cuda import cudnn
+    libcudnn = cudnn
 
 
 def _as4darray(arr):


### PR DESCRIPTION
CuPy v4.0.0b1 introduces the cythonized cuDNN interfaces. It seems to modify the module name of cupy.cudnn. This PR avoids the importing error due to that modification.