### PR TITLE
Support tuple data communication

### DIFF
--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -1,3 +1,5 @@
+import collections
+
 import numpy
 
 import chainer.utils
@@ -14,7 +16,7 @@ class _MessageType(object):
             self.narr = 1
             self.ndims = [obj.ndim]
             self.shapes = [obj.shape]
-        elif isinstance(obj, tuple) or isinstance(obj, list):
+        elif isinstance(obj, collections.Iterable):
             self.is_tuple = True
             self.narr = len(obj)
             self.ndims = [x.ndim for x in obj]

--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -15,7 +15,7 @@ class _MessageType(object):
             self.narr = 1
             self.ndims = [obj.ndim]
             self.shapes = [obj.shape]
-        elif isinstance(obj, tuple):
+        elif isinstance(obj, tuple) or isinstance(obj, list):
             self.is_tuple = True
             self.narr = len(obj)
             self.ndims = [x.ndim for x in obj]
@@ -68,7 +68,7 @@ class CommunicatorBase(object):
         chainer.Variable objects. Please be sure.
 
         Args:
-            obj: data to be sent (tuple or raw numpy/cupy array)
+            obj: data to be sent (tuple, list or raw numpy/cupy array)
             dest (int): Target process specifier.
             tag (int): Message ID (MPI feature).
 

--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -2,6 +2,7 @@ import collections
 
 import numpy
 
+import chainer.cuda
 import chainer.utils
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
@@ -11,7 +12,8 @@ from chainermn import nccl
 class _MessageType(object):
 
     def __init__(self, obj):
-        if isinstance(obj, numpy.ndarray):
+        if isinstance(obj, numpy.ndarray) \
+                or chainer.cuda.get_array_module(obj) is not numpy:
             self.is_tuple = False
             self.narr = 1
             self.ndims = [obj.ndim]
@@ -22,7 +24,8 @@ class _MessageType(object):
             self.ndims = [x.ndim for x in obj]
             self.shapes = [x.shape for x in obj]
         else:
-            raise ValueError('Message object should be numpy array or tuple.')
+            raise ValueError(
+                'Message object must be numpy/cupy array or tuple.')
 
 
 class CommunicatorBase(object):

--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -1,4 +1,3 @@
-import mpi4py.MPI
 import numpy
 
 import chainer.utils

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -3,7 +3,6 @@ import collections
 import chainer
 from chainer import cuda
 import chainer.utils
-import chainermn.functions
 
 
 class Send(chainer.Function):

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -1,3 +1,5 @@
+import collections
+
 import chainer
 from chainer import cuda
 import chainer.utils
@@ -136,7 +138,11 @@ def send(x, communicator, rank, tag=0):
             'rank must be different from communicator rank, '
             'otherwise deadlock occurs')
 
-    delegate_variable = Send(communicator, peer_rank=rank, peer_tag=tag)(x)
+    if isinstance(x, collections.Iterable):
+        delegate_variable = Send(communicator, peer_rank=rank, peer_tag=tag)(*x)
+    else:
+        delegate_variable = Send(communicator, peer_rank=rank, peer_tag=tag)(x)
+
     delegate_variable.name = 'delegate_variable'
     return delegate_variable
 

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -98,13 +98,7 @@ class Recv(chainer.Function):
         self.comm.send(grad_outputs, self.peer_rank, self.peer_tag)
 
         # dummy_var is needed to maintain Chainer's constraint.
-        if inputs == ():
-            dummy_var = tuple([
-                xp.zeros(x.shape, dtype=xp.float32) for x in inputs])
-        else:
-            delegate_variable, = inputs
-            dummy_var = tuple([
-                xp.zeros(delegate_variable.shape, dtype=xp.float32)])
+        dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32) for x in inputs])
 
         return dummy_var
 

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -200,7 +200,7 @@ def recv(
             peer_tag=tag,
             device=device)(delegate_variable)
 
-    if force_tuple and len(res) == 1:
+    if force_tuple and not isinstance(res, tuple):
         return tuple([res])
     else:
         return res

--- a/tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/functions_tests/test_point_to_point_communication.py
@@ -130,3 +130,23 @@ class TestPointToPointCommunication(unittest.TestCase):
             err = chainermn.functions.send(
                 y, self.communicator, self.rank_send)
             err.backward()
+
+    def test_tuple_communication(self):
+        if self.communicator.rank == 0:
+            y0 = self.f(self.model(self.x))
+            y1 = self.f(self.model(self.x))
+            err = chainermn.functions.send(
+                [y0, y1], self.communicator, self.rank_send)
+            err.backward()
+
+        elif self.communicator.rank == self.communicator.size - 1:
+            y0, y1 = chainermn.functions.recv(self.communicator, self.rank_recv, device=self.device)
+            y = y0 + y1
+            err = self.evaluation(y, self.x)
+            err.backward()
+
+        else:
+            y0, y1 = chainermn.functions.recv(self.communicator, self.rank_recv, device=self.device)
+            err = chainermn.functions.send(
+                [y0, y1], self.communicator, self.rank_send)
+            err.backward()

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -201,7 +201,8 @@ class TupleDataParent(chainermn.MultiNodeChainList):
 class TupleDataChild(chainermn.MultiNodeChainList):
     def __init__(self, comm, size, rank_parent):
         super(TupleDataChild, self).__init__(comm=comm)
-        self.add_link(TupleDataSubB(size), rank_in=rank_parent, rank_out=rank_parent)
+        self.add_link(
+            TupleDataSubB(size), rank_in=rank_parent, rank_out=rank_parent)
 
 
 @chainer.testing.parameterize(


### PR DESCRIPTION
The current version of `chainermn.functions.{send,recv}` can communicate with only one array.
This hinders the flexibility of `MultiNodeChainList` since we can't send multiple arrays at the same time:

```python
class NN0(chainer.Chain):
    def __call__(self, x):
        y0 = some_calculation_nn0_0(x)
        y1 = some_calculation_nn1_1(x)
        return y0, y1

class NN1(chainer.Chain):
    def __call__(self, y):
        y0, y1 = y
        return some_calculation_nn1(y0, y1)

class Model_on_Process_0(chainermn.MultiNodeChainList):
    def __init__(self, comm):
        super(Model_on_Process_0, self).__init__(comm=comm)
        self.add_link(NN0(), rank_in=None, rank_out=1)

class Model_on_Process_1(chainermn.MultiNodeChainList):
    def __init__(self, comm):
        super(Model_on_Process_1, self).__init__(comm=comm)
        self.add_link(NN1(), rank_in=0, rank_out=None)
```