### PR TITLE
Avoid sending SubDataset and use broadcast for datasets

### DIFF
--- a/chainermn/datasets/scatter_dataset.py
+++ b/chainermn/datasets/scatter_dataset.py
@@ -5,7 +5,7 @@ import chainer.datasets
 import numpy
 
 
-class DataSizeError(object):
+class DataSizeError(RuntimeError):
     pass
 
 

--- a/chainermn/datasets/scatter_dataset.py
+++ b/chainermn/datasets/scatter_dataset.py
@@ -1,42 +1,85 @@
-import re
+import pickle
 import warnings
 
 import chainer.datasets
 import numpy
 
 
-class DataSizeError(RuntimeError):
-    def __init__(self, ds_size, pickled_size):
-        msg = """The dataset was too large to be scattered using MPI.
-
-        The length of the dataset is {} and it's size after being pickled
-        was {}. In the current MPI specification, the size cannot exceed
-        {}, which is so called 'INT_MAX'.
-
-        To solve this problem, please split the dataset into multiple
-        peaces and send/recv them separately.
-        """
-
-        INT_MAX = 2147483647
-        msg = msg.format(ds_size, pickled_size, INT_MAX)
-        super(DataSizeError, self).__init__(self, msg)
-
-        self.pickled_size = pickled_size
-        self.max_size = INT_MAX
-        self.dataset_size = ds_size
+class DataSizeError(object):
+    pass
 
 
-def _parse_overflow_error(err):
-    msg = str(err)
-    m = re.search(r'integer (\d+) does not fit in', msg)
-    assert m is not None, "'{}' must include size of the message".format(msg)
-    return int(m.group(1))
+INT_MAX = 2147483647
 
 
-_datasize_error_token = "832932439470324903284302"
+def chunked_bcast(obj, comm,
+                  max_buf_len=256 * 1024 * 1024,  # 256MB default
+                  root=0):
+    '''Split object to max_buf_len size chunks and send them out
+
+    As mpi4py does not accept an object whose pickled size is larger
+    than signed integer max (2147483647) the object is pickled and
+    split into chunks.
+
+    Another hack could be try with comm.bcast(obj) then rank 0 node
+    will receive OverflowError from mpi4py. But in that case rank > 0
+    nodes shall block busy waiting forever at comm.bcast(obj).
+
+    Args:
+        obj: A Python object that is to be broadcasted.
+        comm: ChainerMN communicator or MPI4py communicator.
+        root (int): The root process of the scatter operation.
+        max_buf_len (int): Max buffer size to be used at broadcasting
+            binaries. Must not be larger than 2147483647.
+    Returns:
+        Broadcasted object.
+    '''
+    assert max_buf_len < INT_MAX
+    assert max_buf_len > 0
+
+    # check XOR condition of obj is None and rank==0
+    # rank \ obj | None | not None |
+    #   == 0     |  NG  |   OK     |
+    #    > 0     |  OK  |   NG     |
+    assert not (obj is None and comm.rank == root)
+    assert not (obj is not None and comm.rank != root)
+
+    if obj is not None and comm.rank == root:
+        pickled_bytes = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    else:
+        pickled_bytes = bytearray()
+
+    total_bytes = len(pickled_bytes)
+    total_chunk_num = total_bytes // max_buf_len
+    if (total_bytes % max_buf_len) > 0:
+        total_chunk_num += 1
+
+    data = comm.bcast((total_chunk_num, max_buf_len, total_bytes))
+    assert data is not None
+    (total_chunk_num, max_buf_len, total_bytes) = data
+
+    for i in range(total_chunk_num):
+        b = i * max_buf_len
+        e = min(b + max_buf_len, total_bytes)
+
+        if comm.rank == root:
+            buf = pickled_bytes[b:e]
+        else:
+            buf = bytearray(e - b)
+
+        comm.Bcast(buf, root=root)
+
+        if comm.rank != root:
+            pickled_bytes[b:e] = buf
+
+    if comm.rank > root:
+        obj = pickle.loads(pickled_bytes)
+
+    return obj
 
 
-def scatter_dataset(dataset, comm, root=0, shuffle=False, seed=None):
+def scatter_dataset(dataset, comm, root=0, shuffle=False,
+                    seed=None, max_buf_len=256 * 1024 * 1024):
     """Scatter the given dataset to the workers in the communicator.
 
     The dataset of worker 0 (i.e., the worker whose ``comm.rank`` is 0) is
@@ -57,7 +100,8 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False, seed=None):
             specified, it is guaranteed that each sample
             in the given dataset always belongs to a specific subset.
             If ``None``, the permutation is changed randomly.
-
+        max_buf_len (int): Max buffer size to be used at broadcasting
+            binaries. Must not be larger than 2147483647.
     Returns:
         Scattered dataset.
     """
@@ -68,55 +112,41 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False, seed=None):
     assert hasattr(comm, 'recv')
     assert 0 <= root and root < comm.size
 
-    # We cannot use `mpi_comm.scatter`. This is due to MPI4py's bug.
-    # For large datasets, when using `mpi_comm.scatter`, it causes MemoryError.
+    order = None
+    if shuffle and dataset is not None:
+        n_total_samples = len(dataset)
+        order = numpy.random.RandomState(seed).permutation(
+            n_total_samples)
+
+    data = None
+    if comm.rank == 0:
+        data = (dataset, order)
+
+    data = chunked_bcast(data, comm, max_buf_len=max_buf_len)
+    assert data is not None
+    (dataset, order) = data
+
     if comm.rank == root:
-        try:
-            mine = None
-            n_total_samples = len(dataset)
-            n_sub_samples = (n_total_samples + comm.size - 1) // comm.size
-            order = None
+        mine = None
+        n_total_samples = len(dataset)
+        n_sub_samples = (n_total_samples + comm.size - 1) // comm.size
 
-            if shuffle:
-                order = numpy.random.RandomState(seed).permutation(
-                    n_total_samples)
+        for i in range(comm.size):
+            b = n_total_samples * i // comm.size
+            e = b + n_sub_samples
 
-            for i in range(comm.size):
-                b = n_total_samples * i // comm.size
-                e = b + n_sub_samples
-                subds = chainer.datasets.SubDataset(dataset, b, e, order)
-                if i == root:
-                    mine = subds
-                else:
-                    comm.send(subds, dest=i)
-            assert mine is not None
-            return mine
-        except OverflowError as e:
-            pickled_size = _parse_overflow_error(e)
-            ds_err = DataSizeError(len(dataset), pickled_size)
-            # We use a special data to indicate that
-            # an error occured in the root process, so
-            # the receiver processes can handle the error and
-            # call recv() function again (or possibly multiple times)
-            # to receive the whole data.
-            msg = {
-                'token': _datasize_error_token,
-                'pickled_size': ds_err.pickled_size,
-                'dataset_size': ds_err.dataset_size,
-            }
-            for i in range(comm.size):
-                if i != comm.rank:
-                    comm.send(msg, dest=i)
-            raise ds_err
+            if i == root:
+                mine = chainer.datasets.SubDataset(dataset, b, e, order)
+            else:
+                comm.send((b, e), dest=i)
+        assert mine is not None
+        return mine
 
     else:
         data = comm.recv(source=root)
-        if isinstance(data, dict) and (
-                data.get('token') == _datasize_error_token):
-            raise DataSizeError(data['dataset_size'], data['pickled_size'])
-        else:
-            assert data is not None
-            return data
+        assert data is not None
+        (b, e) = data
+        return chainer.datasets.SubDataset(dataset, b, e, order)
 
 
 def get_n_iterations_for_one_epoch(dataset, local_batch_size, comm):

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -454,23 +454,7 @@ def main():
 
     # Broadcast dataset
     # Sanity check of train_data
-
-    # If the pickled size exceeds 4GB, which is a limit of data size
-    # that MPI can send in a single MPI_Send/MPI_Recv,
-    # ChainerMN raises DataSizeError.
-    try:
-        train_data = chainermn.scatter_dataset(train_data, comm)
-    except chainermn.DataSizeError as exc:
-        recv_data = []
-        # Split the train_data into slices
-        # as advised from DataSizeError, and retry sending them.
-        for (b, e) in _slices(exc):
-            if train_data is not None:
-                slice = train_data[b:e]
-            else:
-                slice = None
-            recv_data += chainermn.scatter_dataset(slice, comm)
-        train_data = recv_data
+    train_data = chainermn.scatter_dataset(train_data, comm)
 
     test_data = chainermn.scatter_dataset(test_data, comm)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -12,9 +12,6 @@ from chainermn.communicators.naive_communicator import NaiveCommunicator
 from chainermn.datasets.scatter_dataset import chunked_bcast  # NOQA
 from chainermn.datasets.scatter_dataset import INT_MAX  # NOQA
 
-from chainermn.datasets import DataSizeError
-from chainermn.datasets import scatter_dataset
-
 
 class TestDataset(unittest.TestCase):
 
@@ -82,12 +79,11 @@ class TestDataset(unittest.TestCase):
 
     def scatter_large_data(self, comm_type):
         comm = self.communicator
+        data = []
         if comm.rank == 0:
             data = ["test"] * 2000000000
-            data = chainermn.scatter_dataset(data, comm)
-        else:
-            data = []
-            data = scatter_dataset(data, comm)
+        data = chainermn.scatter_dataset(data, comm)
+        assert len(data) > 0
 
     @attr(slow=True)
     def test_scatter_large_dataset(self):
@@ -95,8 +91,5 @@ class TestDataset(unittest.TestCase):
         if self.communicator.size == 1:
             raise nose.plugins.skip.SkipTest()
 
-        # This test inherently requires large memory (>4GB) and
-        # we skip this test so far.
         for comm_type in ['naive', 'flat']:
-            self.assertRaises(DataSizeError,
-                              lambda: self.scatter_large_data(comm_type))
+            self.scatter_large_data(comm_type)


### PR DESCRIPTION
In mpi4py objects sent with Comm.send() are always pickled every time;
Thus, whole dataset is pickled at sending to each of all rank > 0
nodes, as self._dataset is included in all SubDataset [1]. Thus in
scatter_dataset function has been inefficient that took >30 seconds
when distributing ImageNet 2012 dataset, even if it was just for file
names and tags, for example, which is optimized to finish in <5
seconds in our experimental environment.

This patch changes the repeat of Comm.send() to a combination of
Comm.bcast() of whole dataset and Comm.send() of range of each
scattered dataset. With this change number of picking whole dataset
has been reduced from N to 1, where N denotes number of MPI processes.

But this fix as a drawback in error handling, especially in case
OverflowError is raised by mpi4py. Rank 0 node may handle that error
because it knows the error, while other nodes may or may not know the
error and may wait for broadcast message for ever in busy loop. Those
behavior shall depend on MPI implementation, as it is not defined in
MPI specification 3.1 [2] afaik.

To solve the second issue dataset passed to scatter_dataset() is
forcible split into chunks whose default size is 256MB. This size is
configurable, but must not be larger than max value of signed integer.
And those chunks will be sent via a course of Comm.Bcast() instead of
single Comm.bcast(). Also, chainermn.datasets.DataSizeError is
emptied.

Note that any dataset passed to scatter_dataset() is forcibly pickled
into single buffer without any streaming, and the pickling and unpickling
may consume long time proportional to the size of the dataset.

[1] https://github.com/chainer/chainer/blob/v3.1.0/chainer/datasets/sub_dataset.py#L50
[2] http://mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf

Note: this is a substitute and rebased version of #138.