### PR TITLE
Add simple and distributed checkpointing and automatic recovery

### DIFF
--- a/chainermn/__init__.py
+++ b/chainermn/__init__.py
@@ -10,6 +10,7 @@ from chainermn.communicators import create_communicator  # NOQA
 from chainermn.datasets import DataSizeError  # NOQA
 from chainermn.datasets import scatter_dataset  # NOQA
 from chainermn.extensions import create_multi_node_evaluator  # NOQA
+from chainermn.extensions import distributed_cpr  # NOQA
 from chainermn.links import MultiNodeChainList  # NOQA
 from chainermn.optimizers import create_multi_node_optimizer  # NOQA
 

--- a/chainermn/extensions/__init__.py
+++ b/chainermn/extensions/__init__.py
@@ -1,1 +1,2 @@
+from chainermn.extensions.checkpoint import distributed_cpr  # NOQA
 from chainermn.extensions.multi_node_evaluator import create_multi_node_evaluator  # NOQA

--- a/chainermn/extensions/checkpoint.py
+++ b/chainermn/extensions/checkpoint.py
@@ -1,0 +1,286 @@
+import os
+import shutil
+import tempfile
+import time
+
+import chainer
+from chainer.training import extension
+
+
+def distributed_cpr(name, comm, cp_interval=5, gc_interval=5, path=None):
+    '''Create Distributed CPR Extension
+
+    Generational snapshot extension to allow fault tolerance;
+    It keeps several old snapshots to rollback synchronized
+    snapshot at each MPI process. Snapshot files are identified
+    as '<name>.<rank>.<iteration>'.
+    <name> ... identifier of the run where snapshot is kept for
+    <rank> ... which process owned the model
+    <iteration> ... number of iteration.
+
+    This extension keeps several files for each execution and allows
+    users to resume the whole job at the latest snapshots of each MPI
+    process, and the iteration where all snapshots agrees.
+
+    As this object is a usual Chainer extension, users can just
+    create this object and pass to the trainer as an extension::
+
+        cpr = distributed_cpr(name=run_id, comm=comm)
+        trainer.extend(cpr, trigger=(25, 'iteration'))
+
+    To run recovery at startup, before first iteration, run::
+
+        cpr.maybe_resume(trainer, optimizer)
+
+    before ``trainer.run()`` . If nothing is recovered (i.e. no
+    snapshot found), ``trainer.updater.iteration`` will remain ``0``
+    . Otherwise it will have the value of snapshot and the training
+    will resume from that iteration. ``optimizer`` is optional but
+    this will let multi node optimizer avoid initial broadcast when
+    all snapshot data among nodes are all in sync.
+
+    Another example to use CPR *without* trainer would be::
+
+        cpr = distributed_cpr(name=run_id, comm=comm)
+        cpr.maybe_resume(obj_you_want_to_cpr, optimizer)
+
+        while True: ## Training loop
+            ...
+            updater.update()
+            ...
+            cpr.checkpoint(obj_you_want_to_cpr)  # Update checkpoints
+
+    c.f. Taking snapshots in single node execution would be much simpler::
+
+        trainer.extend(extensions.snapshot())
+
+    TODO(kuenishi): do we need checksum? ... snapshot_object is smart
+    that uses temporary files and then moving the file, which is
+    usually an atomic operation. If we assume external (malicious or
+    innocent) hands such as bit rot or file truncate we need this. In
+    current implementation manual removal of latest snapshot files will
+    let recovery happen against next-latest snapshot.
+    TODO(kuenishi): make non-distributed version and contribute to Chainer?
+
+    Args:
+        name (str): unique id of the run
+        comm: communicater in ChainerMN
+        cp_interval (int): number of checkpoints to guarantee preserved
+        gc_interval (int): interval to collect non-preserved checkpoints
+    '''
+    return _DistCPRExtension(name, comm, cp_interval, gc_interval, path)
+
+
+class _CPRStats(object):
+    def __init__(self):
+        self.timings = []
+        self.begin = None
+
+    def start(self):
+        self.begin = time.time()
+
+    def end(self):
+        e = time.time()
+
+        if self.begin is None:
+            return
+
+        self.timings.append({'b': self.begin, 'd': e - self.begin})
+        self.begin = None
+
+    def report(self):
+        count = len(self.timings)
+        if count == 0:
+            return 'No stats available'
+
+        durations = [t['d'] for t in self.timings]
+        average = sum(durations) / count
+        fmt_str = "Snapshot duration stats (sec): avg={:f}, min={:f}, max={:f}"
+        return fmt_str.format(average, min(durations), max(durations))
+
+
+class _DistCPRExtension(extension.Extension):
+
+    def __init__(self, name, comm, cp_interval, gc_interval, path):
+        self.name = name
+        self.cp_interval = cp_interval
+        self.gc_interval = gc_interval
+        self.comm = comm
+        self.files = []
+        self.stats = _CPRStats()
+
+        # TODO(kuenishi): support path expression such as
+        # 'path/{rank}/snapshot' or 'path/{host}/snapshot'
+        if path is not None:
+            self.path = path
+            os.makedirs(self.path, exist_ok=True)
+        else:
+            self.path = None
+
+        assert name is not None
+        assert self.cp_interval > 0
+        assert self.gc_interval > 0
+        assert self.comm is not None
+
+    def __call__(self, trainer):
+        # This is supposed to be called at the exact same interval
+        # among all nodes
+        if self.path is None:
+            # Note: In a non-trainer use case this path will fail; You
+            # shouldn't pass None at __init__().
+            self.path = trainer.out
+
+        self.checkpoint(trainer, trainer.updater.iteration)
+
+    def checkpoint(self, target, iteration):
+        filename = self._filename(iteration)
+
+        self.stats.start()
+        _save(self.path, filename, target)
+        self.stats.end()
+
+        self.files.append(filename)
+
+        if len(self.files) - self.cp_interval > 5:
+            # remove older snapshots, and bcast latest list
+            self._sync_file_list(remove_remainder=True)
+
+    def finalize(self):
+        assert self.path is not None
+
+        files2remove = self.files
+        for file in files2remove:
+            filename = os.path.join(self.path, file)
+            try:
+                os.remove(filename)
+            except Exception:
+                pass
+
+        self.files = []
+
+    def get_stats(self):
+        return self.stats.report()
+
+    def _sync_file_list(self, remove_remainder=False):
+        file_lists = self.comm.mpi_comm.gather(self.files, root=0)
+
+        iters0 = None
+        if self.comm.rank == 0:
+            if file_lists is not None:
+                if len(file_lists) == 0:
+                    self.files = []
+                    return
+
+                iters0 = set(
+                    [i for _, _, i in self._parse_filenames(file_lists[0])])
+                for files in file_lists[1:]:
+                    iters = set(
+                        [i for _, _, i in self._parse_filenames(files)])
+                    iters0 &= iters
+
+                iters0 = list(iters0)
+                iters0.sort()
+                iters0 = iters0[-self.cp_interval:]
+
+            else:
+                raise RuntimeError("Can't gather checkpoint file names")
+
+        iters0 = self.comm.mpi_comm.bcast(iters0, root=0)
+        files = self._filenames(iters0)
+
+        if remove_remainder:
+            files2remove = set(self.files) - set(files)
+            for file in files2remove:
+                try:
+                    os.remove(os.path.join(self.path, file))
+                except Exception:
+                    pass
+
+        self.files = files
+
+    def _filenames(self, iterations):
+        return [self._filename(i) for i in iterations]
+
+    def _filename(self, iteration):
+        # TODO(kuenishi): As a node identifier, should we use node
+        # name (e.g. hostname) or MPI rank?
+        #
+        # hostname is fine when MPI rank changes among same set of nodes.
+        # MPI rank is fine when node fails and a new node has come.
+        filename = '{:s}.{:d}.{:d}'.format(
+            self.name, self.comm.rank, iteration)
+        return filename
+
+    def _parse_filenames(self, filenames):
+        # extract filenames and return [ <iteration> ]
+        return [self._parse_filename(f) for f in filenames]
+
+    def _parse_filename(self, filename):
+        tpl = filename.split('.')
+        if len(tpl) != 3:
+            return
+        name, rank, iter = tpl
+        if name != self.name:
+            return
+        return name, int(rank), int(iter)
+
+    def maybe_resume(self, trainer, optimizer=None, path=None):
+        # If there's existing model, load, sync, and resume.
+        if self.path is None:
+            if path is not None:
+                self.path = path
+            else:
+                self.path = trainer.out
+
+        local_files = []
+        try:
+            local_files = os.listdir(self.path)
+        except FileNotFoundError:
+            # Maybe I am the only process that does not have result
+            # directory.
+            pass
+        local_iters = filter(None, self._parse_filenames(local_files))
+        local_iters = [i for name, rank, i in local_iters if name ==
+                       self.name and rank == self.comm.rank]
+
+        self.files = self._filenames(local_iters)
+        # Collect common file list
+        self._sync_file_list()
+
+        # Get set of common snapshot numbers (=iteration number)
+        iters = [i for name, rank, i in self._parse_filenames(self.files)]
+        if len(iters) > 0:
+            # Adopt latest snapshot from iteration number
+            i = max(iters)
+
+            # Note that CPR only verifies file name - if exception
+            # happens here, currently manual deletion of *latest*
+            # snapshot may CPR work sanely against one older snapshot
+            _load(self.path, self._filename(i), trainer)
+
+            if optimizer is not None:
+                # If this is a complete resume, no broadcast is needed ^^;
+                # 'complete resume' means all workers' snapshot is preserved,
+                # so all workers can assume their loaded model is complete.
+                # Otherwise _MultiNodeOptimizer broadcasts and shares data
+                # from rank 0.
+                optimizer.__setattr__('needs_broadcast', False)
+
+
+def _load(path, filename, target):
+    chainer.serializers.load_npz(os.path.join(path, filename), target)
+
+
+def _save(path, filename, target):
+    # Simple save_npz may cause partial write - instead copied and
+    # modified a bit from chainer.extensions.snapshot.
+    prefix = 'tmp-' + filename
+    fd, tmppath = tempfile.mkstemp(prefix=prefix, dir=path)
+    try:
+        chainer.serializers.save_npz(tmppath, target)
+    except Exception:
+        os.close(fd)
+        os.remove(tmppath)
+        raise
+    os.close(fd)
+    shutil.move(tmppath, os.path.join(path, filename))

--- a/examples/mnist/train_mnist_cpr.py
+++ b/examples/mnist/train_mnist_cpr.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import argparse
+
+import chainer
+import chainer.functions as F
+import chainer.links as L
+from chainer import training
+from chainer.training import extensions
+from mpi4py import MPI
+
+import chainermn
+from chainermn.extensions import distributed_cpr
+
+
+class MLP(chainer.Chain):
+
+    def __init__(self, n_units, n_out):
+        super(MLP, self).__init__(
+            # the size of the inputs to each layer will be inferred
+            l1=L.Linear(784, n_units),  # n_in -> n_units
+            l2=L.Linear(n_units, n_units),  # n_units -> n_units
+            l3=L.Linear(n_units, n_out),  # n_units -> n_out
+        )
+
+    def __call__(self, x):
+        h1 = F.relu(self.l1(x))
+        h2 = F.relu(self.l2(h1))
+        return self.l3(h2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='ChainerMN example: MNIST with CPR enabled')
+    parser.add_argument('--batchsize', '-b', type=int, default=100,
+                        help='Number of images in each mini-batch')
+    parser.add_argument('--communicator', type=str,
+                        default='hierarchical', help='Type of communicator')
+    parser.add_argument('--epoch', '-e', type=int, default=20,
+                        help='Number of sweeps over the dataset to train')
+    parser.add_argument('--gpu', '-g', action='store_true',
+                        help='Use GPU')
+    parser.add_argument('--out', '-o', default='result',
+                        help='Directory to output the result')
+    parser.add_argument('--unit', '-u', type=int, default=1000,
+                        help='Number of units')
+    parser.add_argument('--run-id', type=str, default='train-mnist-example',
+                        help='ID of the task name')
+    args = parser.parse_args()
+
+    # Prepare ChainerMN communicator.
+
+    if args.gpu:
+        if args.communicator == 'naive':
+            print("Error: 'naive' communicator does not support GPU.\n")
+            exit(-1)
+        comm = chainermn.create_communicator(args.communicator)
+        device = comm.intra_rank
+    else:
+        if args.communicator != 'naive':
+            print('Warning: using naive communicator '
+                  'because only naive supports CPU-only execution')
+        comm = chainermn.create_communicator('naive')
+        device = -1
+
+    if comm.mpi_comm.rank == 0:
+        print('==========================================')
+        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        if args.gpu:
+            print('Using GPUs')
+        print('Using {} communicator'.format(args.communicator))
+        print('Num unit: {}'.format(args.unit))
+        print('Num Minibatch-size: {}'.format(args.batchsize))
+        print('Num epoch: {}'.format(args.epoch))
+        print('==========================================')
+
+    model = L.Classifier(MLP(args.unit, 10))
+    if device >= 0:
+        chainer.cuda.get_device(device).use()
+        model.to_gpu()
+
+    # Create a multi node optimizer from a standard Chainer optimizer.
+    optimizer = chainermn.create_multi_node_optimizer(
+        chainer.optimizers.Adam(), comm)
+    optimizer.setup(model)
+
+    # Split and distribute the dataset. Only worker 0 loads the whole dataset.
+    # Datasets of worker 0 are evenly split and distributed to all workers.
+    if comm.rank == 0:
+        train, test = chainer.datasets.get_mnist()
+    else:
+        train, test = None, None
+    train = chainermn.scatter_dataset(train, comm, shuffle=True)
+    test = chainermn.scatter_dataset(test, comm, shuffle=True)
+
+    train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
+    test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
+                                                 repeat=False, shuffle=False)
+
+    updater = training.StandardUpdater(train_iter, optimizer, device=device)
+    trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
+
+    # Enable CPR and recover from checkpoint if any checkpoint exists
+    cpr = distributed_cpr(name=args.run_id, comm=comm)
+    cpr.maybe_resume(trainer, optimizer)
+    print("Rank", comm.rank, ": (Re)Starting from (epoch, iter) =",
+          (trainer.updater.epoch, trainer.updater.iteration))
+    trainer.extend(cpr, trigger=(1000, 'iteration'))
+
+    # Create a multi node evaluator from a standard Chainer evaluator.
+    evaluator = extensions.Evaluator(test_iter, model, device=device)
+    evaluator = chainermn.create_multi_node_evaluator(evaluator, comm)
+    trainer.extend(evaluator)
+
+    # Some display and output extensions are necessary only for one worker.
+    # (Otherwise, there would just be repeated outputs.)
+    if comm.rank == 0:
+        trainer.extend(extensions.dump_graph('main/loss'))
+        trainer.extend(extensions.LogReport())
+        trainer.extend(extensions.PrintReport(
+            ['epoch', 'main/loss', 'validation/main/loss',
+             'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))
+        trainer.extend(extensions.ProgressBar())
+
+    trainer.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import unittest
 
-import mpi4py.MPI
 import numpy as np
 
 import chainer
@@ -13,7 +12,6 @@ import chainer.testing
 from chainer import training
 
 import chainermn
-from chainermn.communicators.naive_communicator import NaiveCommunicator
 from chainermn.extensions.checkpoint import _CPRStats
 from chainermn.extensions.checkpoint import distributed_cpr
 
@@ -35,8 +33,7 @@ class MLP(chainer.Chain):
 class TestCheckpoint(unittest.TestCase):
 
     def setUp(self):
-        self.mpi_comm = mpi4py.MPI.COMM_WORLD
-        self.communicator = NaiveCommunicator(self.mpi_comm)
+        self.communicator = chainermn.create_communicator('naive')
 
     def test_stats(self):
         stats = _CPRStats()
@@ -57,7 +54,7 @@ class TestCheckpoint(unittest.TestCase):
         filenames = cpr._filenames(nums)
         nums2 = []
         for n, r, i in cpr._parse_filenames(filenames):
-            assert self.mpi_comm.rank == r
+            assert self.communicator.rank == r
             assert 'hoge' == n
             nums2.append(i)
 
@@ -68,7 +65,7 @@ class TestCheckpoint(unittest.TestCase):
         assert set(filenames) == set(filenames2)
 
     def setup_mnist_trainer(self, display_log=False):
-        batchsize = 10
+        batchsize = 100
         n_units = 100
 
         comm = self.communicator

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,191 @@
+import os
+import tempfile
+import unittest
+
+import mpi4py.MPI
+import numpy as np
+
+import chainer
+from chainer.dataset import convert
+import chainer.functions as F
+import chainer.links as L
+import chainer.testing
+from chainer import training
+
+import chainermn
+from chainermn.communicators.naive_communicator import NaiveCommunicator
+from chainermn.extensions.checkpoint import _CPRStats
+from chainermn.extensions.checkpoint import distributed_cpr
+
+
+class MLP(chainer.Chain):
+    def __init__(self, n_units, n_out):
+        super(MLP, self).__init__(
+            l1=L.Linear(784, n_units),
+            l2=L.Linear(n_units, n_units),
+            l3=L.Linear(n_units, n_out),
+        )
+
+    def __call__(self, x):
+        h1 = F.relu(self.l1(x))
+        h2 = F.relu(self.l2(h1))
+        return self.l3(h2)
+
+
+class TestCheckpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.mpi_comm = mpi4py.MPI.COMM_WORLD
+        self.communicator = NaiveCommunicator(self.mpi_comm)
+
+    def test_stats(self):
+        stats = _CPRStats()
+
+        for i in range(1024):
+            stats.start()
+            stats.end()
+
+        assert isinstance(stats.report(), str)
+
+        stats = _CPRStats()
+        assert isinstance(stats.report(), str)
+
+    def test_filename_converters(self):
+        cpr = distributed_cpr(name='hoge', comm=self.communicator,
+                              cp_interval=23, gc_interval=32)
+        nums = [np.random.randint(4096) for _ in range(234)]
+        filenames = cpr._filenames(nums)
+        nums2 = []
+        for n, r, i in cpr._parse_filenames(filenames):
+            assert self.mpi_comm.rank == r
+            assert 'hoge' == n
+            nums2.append(i)
+
+        assert set(nums) == set(nums2)
+
+        filenames2 = cpr._filenames(nums2)
+
+        assert set(filenames) == set(filenames2)
+
+    def setup_mnist_trainer(self, display_log=False):
+        batchsize = 10
+        n_units = 100
+
+        comm = self.communicator
+        model = L.Classifier(MLP(n_units, 10))
+
+        optimizer = chainermn.create_multi_node_optimizer(
+            chainer.optimizers.Adam(), comm)
+        optimizer.setup(model)
+
+        if comm.rank == 0:
+            train, test = chainer.datasets.get_mnist()
+        else:
+            train, test = None, None
+
+        train = chainermn.scatter_dataset(train, comm, shuffle=True)
+        test = chainermn.scatter_dataset(test, comm, shuffle=True)
+
+        train_iter = chainer.iterators.SerialIterator(train, batchsize)
+        test_iter = chainer.iterators.SerialIterator(test, batchsize,
+                                                     repeat=False,
+                                                     shuffle=False)
+
+        updater = training.StandardUpdater(
+            train_iter,
+            optimizer
+        )
+
+        return updater, optimizer, train_iter, test_iter, model
+
+    def test_mnist_simple(self, display_log=True):
+        updater, optimizer, train_iter, _, model = self.setup_mnist_trainer()
+
+        path = tempfile.mkdtemp(dir='/tmp', prefix=__name__ + "-tmp-")
+        if display_log:
+            print("temporary file:", path)
+        cpr = distributed_cpr(name=__name__, comm=self.communicator, path=path)
+        cpr.maybe_resume(updater, optimizer)
+
+        sum_accuracy = 0
+        sum_loss = 0
+        stop = 5
+        train_count = len(train_iter.dataset)
+        while train_iter.epoch < stop:
+            batch = train_iter.next()
+            x_array, t_array = convert.concat_examples(batch, -1)
+            x = chainer.Variable(x_array)
+            t = chainer.Variable(t_array)
+            optimizer.update(model, x, t)
+
+            sum_loss += float(model.loss.data) * len(t.data)
+            sum_accuracy += float(model.accuracy.data) * len(t.data)
+
+            if train_iter.is_new_epoch:
+                if display_log:
+                    print(updater.iteration, train_iter.epoch,
+                          sum_loss / train_count, sum_accuracy / train_count)
+                sum_loss = 0
+                sum_accuracy = 0
+
+                cpr.checkpoint(updater, updater.iteration)
+
+        if display_log:
+            print(self.communicator.rank, cpr.get_stats())
+
+        # Allocate totally different set of training tools to avoid leakage
+        data_2 = self.setup_mnist_trainer()
+        updater2, optimizer2, train_iter2, test_iter2, model2 = data_2
+        cpr2 = distributed_cpr(
+            name=__name__, comm=self.communicator, path=path)
+        cpr2.maybe_resume(updater2, optimizer2)
+
+        # Check data properly resumed
+        self.assertEqual(updater.epoch, updater2.epoch)
+        self.assertEqual(updater.iteration, updater2.iteration)
+        # TODO(kuenishi): find a simple way to assure model equality
+        # in terms of float matrix
+        # self.assertEqual(model, model2)
+
+        # Restart training
+        while train_iter2.epoch < stop * 2:
+            batch = train_iter2.next()
+            x_array, t_array = convert.concat_examples(batch, -1)
+            x = chainer.Variable(x_array)
+            t = chainer.Variable(t_array)
+            optimizer2.update(model2, x, t)
+
+            sum_loss += float(model2.loss.data) * len(t.data)
+            sum_accuracy += float(model2.accuracy.data) * len(t.data)
+
+            if train_iter2.is_new_epoch:
+                print(updater2.iteration, train_iter2.epoch,
+                      sum_loss / train_count, sum_accuracy / train_count)
+                sum_loss = 0
+                sum_accuracy = 0
+
+                cpr2.checkpoint(updater2, updater2.iteration)
+
+        if display_log:
+            print(self.communicator.rank, cpr2.get_stats())
+        cpr2.finalize()
+        cpr.finalize()
+
+        # Validate training
+        sum_accuracy = 0
+        sum_loss = 0
+        test_count = len(test_iter2.dataset)
+        for batch in test_iter2:
+            x_array, t_array = convert.concat_examples(batch, -1)
+            x = chainer.Variable(x_array)
+            t = chainer.Variable(t_array)
+            loss = model2(x, t)
+            sum_loss += float(loss.data) * len(t.data)
+            sum_accuracy += float(model2.accuracy.data) * len(t.data)
+
+        if display_log:
+            print('test mean  loss: {}, accuracy: {}'.format(
+                sum_loss / test_count, sum_accuracy / test_count))
+
+        self.assertGreaterEqual(sum_accuracy / test_count, 0.95)
+        os.removedirs(path)

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -110,5 +110,6 @@ class TestMNIST(unittest.TestCase):
         self.assertEqual(0, len(os.listdir(path)))
         os.removedirs(path)
 
+
 if __name__ == "__main__":
     TestMNIST().test_mnist(display_log=True)


### PR DESCRIPTION
At each distributed checkpointing, all processes run MPI gather and
MPI bcast to share common set of iteration numbers that has
corresponding snapshot. Also at startup it runs syncing among
procceses, if _DistCPRExtension.maybe_resume() is explicitly called.

Limitations
* Number of nodes must be the same among runs
* In resuming all processes must reachable to its own snapshot files
  that has corresponding rank numbers
* Needs manual operation when any latest set of files are broken;
  just remove them and use one more older set
