### PR TITLE
Added PYTHONWARNING env var to .tavis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ script:
   - flake8 --config=.flake8.cython .
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
+  - export PYTHONWARNINGS='ignore::FutureWarning'
   - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' || exit $?; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;


### PR DESCRIPTION
In the current `.travis.yml` script, the unit tests produce warnings such as 
```
/home/kfukuda/.pyenv/versions/anaconda3-4.3.1/lib/python3.6/site-packages/chainer/utils/experimental.py:104: FutureWarning: chainermn.communicators.CommunicatorBase.all_to_all is experimental. The interface can change in the future.
  FutureWarning)
```

This is annoying and makes reading the CI log harder. 

This PR adds a line to specify `PYTHONWARNINGS` environmental variable to supress `FutureWarning` warnings from Python interpreter.

