### PR TITLE
Remove outdated cudnn variable to make compatible with CuPy v4

### DIFF
--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -9,11 +9,6 @@ from chainer.utils import type_check
 import numpy
 
 
-if cuda.cudnn_enabled:
-    cudnn = cuda.cudnn
-    libcudnn = cudnn.cudnn
-
-
 def _as4darray(arr):
     if arr.ndim == 0:
         return arr.reshape(1, 1, 1, 1)


### PR DESCRIPTION
I removed a variable that causes ChainerMN to crash when used with the latest CuPy version. `chainer.cuda.cudnn.cudnn` has been renamed `chainer.cuda.cudnn.py_cudnn`, but since it was not used in the code, I simply removed it.