### PR TITLE
Fix update bug in MultiNodeOptimizer

### DIFF
--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -7,6 +7,8 @@ class _MultiNodeOptimizer(object):
             'actual_optimizer', actual_optimizer)
         super(_MultiNodeOptimizer, self).__setattr__(
             'needs_broadcast', True)
+        super(_MultiNodeOptimizer, self).__setattr__(
+            'target_params', [])
 
     def update(self, lossfun=None, *args, **kwds):
         target = self.target
@@ -20,13 +22,27 @@ class _MultiNodeOptimizer(object):
             loss.backward()
             del loss
 
-        if self.needs_broadcast:
+        if self.is_changed(target):
             self.communicator.broadcast_data(target)
             super(_MultiNodeOptimizer, self).__setattr__(
                 'needs_broadcast', False)
         else:
             self.communicator.allreduce_grad(target)
             self.actual_optimizer.update(None, *args, **kwds)
+
+    def is_changed(self, target):
+        previous_params = self.target_params
+        super(_MultiNodeOptimizer, self).__setattr__(
+            'target_params', [(name, param.data is not None) for name, param in sorted(target.namedparams())])
+        if len(previous_params) == len(self.target_params):
+            for param1, param2 in zip(self.target_params, previous_params):
+                if param1[0] != param2[0]:
+                    return True
+                if param1[1] != param2[1]:
+                    return True
+            return False
+        else:
+            return True
 
     def __getattr__(self, attr_name):
         return getattr(self.actual_optimizer, attr_name)

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -31,15 +31,13 @@ class _MultiNodeOptimizer(object):
         super(_MultiNodeOptimizer, self).__setattr__(
             'target_params', [(name, param.data is not None)
                               for name, param in sorted(target.namedparams())])
-        if len(previous_params) == len(self.target_params):
-            for param1, param2 in zip(self.target_params, previous_params):
-                if param1[0] != param2[0]:
-                    return True
-                if param1[1] != param2[1]:
-                    return True
-            return False
-        else:
+        if len(previous_params) != len(self.target_params):
             return True
+
+        for param1, param2 in zip(self.target_params, previous_params):
+            if (param1[0] != param2[0]) or param1[1] != param2[1]:
+                return True
+        return False
 
     def __getattr__(self, attr_name):
         return getattr(self.actual_optimizer, attr_name)

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -29,7 +29,8 @@ class _MultiNodeOptimizer(object):
     def is_changed(self, target):
         previous_params = self.target_params
         super(_MultiNodeOptimizer, self).__setattr__(
-            'target_params', [(name, param.data is not None) for name, param in sorted(target.namedparams())])
+            'target_params', [(name, param.data is not None)
+                              for name, param in sorted(target.namedparams())])
         if len(previous_params) == len(self.target_params):
             for param1, param2 in zip(self.target_params, previous_params):
                 if param1[0] != param2[0]:

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -6,8 +6,6 @@ class _MultiNodeOptimizer(object):
         super(_MultiNodeOptimizer, self).__setattr__(
             'actual_optimizer', actual_optimizer)
         super(_MultiNodeOptimizer, self).__setattr__(
-            'needs_broadcast', True)
-        super(_MultiNodeOptimizer, self).__setattr__(
             'target_params', [])
 
     def update(self, lossfun=None, *args, **kwds):
@@ -24,8 +22,6 @@ class _MultiNodeOptimizer(object):
 
         if self.is_changed(target):
             self.communicator.broadcast_data(target)
-            super(_MultiNodeOptimizer, self).__setattr__(
-                'needs_broadcast', False)
         else:
             self.communicator.allreduce_grad(target)
             self.actual_optimizer.update(None, *args, **kwds)

--- a/tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/optimizer_tests/test_multi_node_optimizer.py
@@ -1,0 +1,228 @@
+import chainer
+import chainer.testing
+import chainer.testing.attr
+import chainermn
+from chainermn import nccl
+import mock
+import nose
+import numpy as np
+import unittest
+
+
+class ExampleModel(chainer.Chain):
+
+    def __init__(self):
+        super(ExampleModel, self).__init__(
+            a=chainer.links.Linear(2, 3),
+            b=chainer.links.Linear(3, 4),
+            c=chainer.links.Linear(4, 5),
+        )
+
+
+class TestMultiNodeOptimizer(unittest.TestCase):
+
+    def setup_cpu(self):
+        self.comm = chainermn.create_communicator('naive')
+        self.target = ExampleModel()
+        self.target.a.W.data[:] = self.comm.rank
+        self.target.b.W.data[:] = self.comm.rank + 1
+        self.target.c.W.data[:] = self.comm.rank + 2
+        self.target.a.W.grad[:] = 0
+        self.target.b.W.grad[:] = 0
+        self.target.c.W.grad[:] = 0
+        self.actual_optimizer = chainer.GradientMethod()
+        self.actual_optimizer.create_update_rule = mock.MagicMock
+        self.actual_optimizer.setup(self.target)
+
+    def setup_gpu(self, device=None):
+        self.comm = chainermn.create_communicator('hierarchical')
+        device = self.comm.intra_rank
+        chainer.cuda.get_device(device).use()
+        self.target = ExampleModel()
+        self.target.to_gpu()
+        self.target.a.W.data[:] = self.comm.rank
+        self.target.b.W.data[:] = self.comm.rank + 1
+        self.target.c.W.data[:] = self.comm.rank + 2
+        self.target.a.W.grad[:] = 0
+        self.target.b.W.grad[:] = 0
+        self.target.c.W.grad[:] = 0
+        self.actual_optimizer = chainer.GradientMethod()
+        self.actual_optimizer.create_update_rule = mock.MagicMock
+        self.actual_optimizer.setup(self.target)
+
+    def test_update_with_cpu(self):
+        self.setup_cpu()
+        self.optimizer = chainermn.create_multi_node_optimizer(
+            self.actual_optimizer, self.comm)
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+        self.optimizer.target.a.W.grad[:] = self.comm.rank
+        self.optimizer.target.b.W.grad[:] = self.comm.rank + 1
+        self.optimizer.target.c.W.grad[:] = self.comm.rank + 2
+
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 1)
+        self.optimizer.target.a.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.a.W)
+        self.optimizer.target.b.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.b.W)
+        self.optimizer.target.c.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.c.W)
+
+        base = (self.comm.size - 1.0) / 2
+        chainer.testing.assert_allclose(self.optimizer.target.a.W.grad,
+                                        (base + 0) * np.ones((3, 2)))
+        chainer.testing.assert_allclose(self.optimizer.target.b.W.grad,
+                                        (base + 1) * np.ones((4, 3)))
+        chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
+                                        (base + 2) * np.ones((5, 4)))
+
+    @chainer.testing.attr.gpu
+    def test_update_with_gpu(self):
+        self.setup_gpu()
+        self.optimizer = chainermn.create_multi_node_optimizer(
+            self.actual_optimizer, self.comm)
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+        self.optimizer.target.a.W.grad[:] = self.comm.rank
+        self.optimizer.target.b.W.grad[:] = self.comm.rank + 1
+        self.optimizer.target.c.W.grad[:] = self.comm.rank + 2
+
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 1)
+        self.optimizer.target.a.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.a.W)
+        self.optimizer.target.b.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.b.W)
+        self.optimizer.target.c.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.c.W)
+
+        base = (self.comm.size - 1.0) / 2
+        chainer.testing.assert_allclose(self.optimizer.target.a.W.grad,
+                                        (base + 0) * np.ones((3, 2)))
+        chainer.testing.assert_allclose(self.optimizer.target.b.W.grad,
+                                        (base + 1) * np.ones((4, 3)))
+        chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
+                                        (base + 2) * np.ones((5, 4)))
+
+
+
+class DynamicExampleModel(chainer.Chain):
+
+    def __init__(self):
+        super(DynamicExampleModel, self).__init__()
+        with self.init_scope():
+            self.a=chainer.links.Linear(2, 3)
+            self.b=chainer.links.Linear(3, 4)
+
+
+class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
+    
+    def setup_cpu(self):
+        self.comm = chainermn.create_communicator('naive')
+        self.target = DynamicExampleModel()
+        self.target.a.W.data[:] = self.comm.rank
+        self.target.b.W.data[:] = self.comm.rank + 1
+        self.target.a.W.grad[:] = 0
+        self.target.b.W.grad[:] = 0
+        self.actual_optimizer = chainer.GradientMethod()
+        self.actual_optimizer.create_update_rule = mock.MagicMock
+        self.actual_optimizer.setup(self.target)
+
+    def setup_gpu(self, device=None):
+        self.comm = chainermn.create_communicator('hierarchical')
+        device = self.comm.intra_rank
+        chainer.cuda.get_device(device).use()
+        self.target = DynamicExampleModel()
+        self.target.to_gpu()
+        self.target.a.W.data[:] = self.comm.rank
+        self.target.b.W.data[:] = self.comm.rank + 1
+        self.target.a.W.grad[:] = 0
+        self.target.b.W.grad[:] = 0
+        self.actual_optimizer = chainer.GradientMethod()
+        self.actual_optimizer.create_update_rule = mock.MagicMock
+        self.actual_optimizer.setup(self.target)
+
+    def test_update_with_cpu(self):
+        self.setup_cpu()
+        self.optimizer = chainermn.create_multi_node_optimizer(
+            self.actual_optimizer, self.comm)
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+        
+        with self.target.init_scope():
+            self.target.c = chainer.links.Linear(4, 4)
+        if self.comm.rank == 0:
+            self.target.c.W.data[:] = self.comm.rank + 2
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+                
+        send_buf = chainer.cuda.to_cpu(self.optimizer.target.c.W.data)
+        recv_buf = self.comm.mpi_comm.allgather(send_buf)
+        for i in range(1, self.comm.size):
+            print(recv_buf[i], flush=True)
+            chainer.testing.assert_allclose(recv_buf[0], recv_buf[i])
+
+        self.optimizer.target.a.W.grad[:] = self.comm.rank
+        self.optimizer.target.b.W.grad[:] = self.comm.rank + 1
+        self.optimizer.target.c.W.grad[:] = self.comm.rank + 2
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 1)
+        self.optimizer.target.a.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.a.W)
+        self.optimizer.target.b.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.b.W)
+        self.optimizer.target.c.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.c.W)
+
+        base = (self.comm.size - 1.0) / 2
+        chainer.testing.assert_allclose(self.optimizer.target.a.W.grad,
+                                        (base + 0) * np.ones((3, 2)))
+        chainer.testing.assert_allclose(self.optimizer.target.b.W.grad,
+                                        (base + 1) * np.ones((4, 3)))
+        chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
+                                        (base + 2) * np.ones((5, 4)))
+
+    @chainer.testing.attr.gpu
+    def test_update_with_gpu(self):
+        self.setup_gpu()
+        self.optimizer = chainermn.create_multi_node_optimizer(
+            self.actual_optimizer, self.comm)
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+        
+        with self.target.init_scope():
+            c = chainer.links.Linear(4, 4)
+            c.to_gpu()
+            self.target.c = c 
+        if self.comm.rank == 0:
+            self.target.c.W.data[:] = self.comm.rank + 2
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 0)
+                
+        send_buf = chainer.cuda.to_cpu(self.optimizer.target.c.W.data)
+        recv_buf = self.comm.mpi_comm.allgather(send_buf)
+        for i in range(1, self.comm.size):
+            print(recv_buf[i], flush=True)
+            chainer.testing.assert_allclose(recv_buf[0], recv_buf[i])
+
+        self.optimizer.target.a.W.grad[:] = self.comm.rank
+        self.optimizer.target.b.W.grad[:] = self.comm.rank + 1
+        self.optimizer.target.c.W.grad[:] = self.comm.rank + 2
+        self.optimizer.update()
+        self.assertEqual(self.actual_optimizer.t, 1)
+        self.optimizer.target.a.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.a.W)
+        self.optimizer.target.b.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.b.W)
+        self.optimizer.target.c.W.update_rule.update.assert_called_once_with(
+            self.optimizer.target.c.W)
+
+        base = (self.comm.size - 1.0) / 2
+        chainer.testing.assert_allclose(self.optimizer.target.a.W.grad,
+                                        (base + 0) * np.ones((3, 2)))
+        chainer.testing.assert_allclose(self.optimizer.target.b.W.grad,
+                                        (base + 1) * np.ones((4, 3)))
+        chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
+                                        (base + 2) * np.ones((5, 4)))
+

--- a/tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/optimizer_tests/test_multi_node_optimizer.py
@@ -3,13 +3,8 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 import mock
-import mpi4py.MPI
-import nose
 import numpy as np
 import unittest
-
-
-from chainermn.communicators import _communication_utility
 
 
 class ExampleModel(chainer.Chain):
@@ -109,14 +104,13 @@ class TestMultiNodeOptimizer(unittest.TestCase):
                                         (base + 2) * np.ones((5, 4)))
 
 
-
 class DynamicExampleModel(chainer.Chain):
 
     def __init__(self):
         super(DynamicExampleModel, self).__init__()
         with self.init_scope():
-            self.a=chainer.links.Linear(2, 3)
-            self.b=chainer.links.Linear(3, 4)
+            self.a = chainer.links.Linear(2, 3)
+            self.b = chainer.links.Linear(3, 4)
 
 
 class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
@@ -151,7 +145,7 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
         self.optimizer.setup(self.target)
         self.optimizer.update()
         self.assertEqual(self.actual_optimizer.t, 0)
-        
+
         with self.target.init_scope():
             self.target.c = chainer.links.Linear(4, 4)
         if self.comm.rank == 0:
@@ -159,7 +153,7 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
         self.optimizer.setup(self.target)
         self.optimizer.update()
         self.assertEqual(self.actual_optimizer.t, 0)
-                
+
         send_buf = chainer.cuda.to_cpu(self.optimizer.target.c.W.data)
         recv_buf = self.comm.mpi_comm.allgather(send_buf)
         for i in range(1, self.comm.size):
@@ -193,17 +187,17 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
         self.optimizer.setup(self.target)
         self.optimizer.update()
         self.assertEqual(self.actual_optimizer.t, 0)
-        
+
         with self.target.init_scope():
             c = chainer.links.Linear(4, 4)
             c.to_gpu()
-            self.target.c = c 
+            self.target.c = c
         if self.comm.rank == 0:
             self.target.c.W.data[:] = self.comm.rank + 2
         self.optimizer.setup(self.target)
         self.optimizer.update()
         self.assertEqual(self.actual_optimizer.t, 0)
-                
+
         send_buf = chainer.cuda.to_cpu(self.optimizer.target.c.W.data)
         recv_buf = self.comm.mpi_comm.allgather(send_buf)
         for i in range(1, self.comm.size):
@@ -228,4 +222,3 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
                                         (base + 1) * np.ones((4, 3)))
         chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
                                         (base + 2) * np.ones((4, 4)))
-


### PR DESCRIPTION
When a new layer is added to a model dynamically, its parameters needs to be sent all nodes.
But, the current MultiNodeOptimizer only sends model parameters first once.
Therefore, I fixed MultinodeOptimizer to send parameters all nodes when a model is changed.