### PR TITLE
Change MultiNodeEvaluator to object patching from proxy pattern

### DIFF
--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -1,23 +1,26 @@
 import types
 
 
-def create_multi_node_evaluator(actual_evaluator, communicator):
+def create_multi_node_evaluator(evaluator, communicator):
     """Create a multi node evaluator from a normal evaluator.
 
-    Actually patches the evaluator to work with multinode
-    optimizer.
+    Actually patches the evaluator to work in multinode
+    environment. This method adds several hidden attributes starting
+    with _mn_ prefix. After the patch, original evaluator does not
+    work correctly in non-MPI environment.
 
     Args:
-        actual_evaluator: evaluator
+        evaluator: evaluator to be patched
             (e.g., ``chainer.training.extensions.Evaluator``)
         communicator: ChainerMN communicator
 
     Returns:
-        The multi node evaluator based on ``actual_evaluator``.
+        The multi node evaluator based on ``evaluator``.
+
     """
 
-    actual_evaluator._mn_original_evaluate = actual_evaluator.evaluate
-    actual_evaluator._mn_communicator = communicator
+    evaluator._mn_original_evaluate = evaluator.evaluate
+    evaluator._mn_communicator = communicator
 
     def new_evaluate(self):
         local_mean_dict = self._mn_original_evaluate()
@@ -29,6 +32,5 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
         }
         return global_mean_dict
 
-    actual_evaluator.evaluate = types.MethodType(
-        new_evaluate, actual_evaluator)
-    return actual_evaluator
+    evaluator.evaluate = types.MethodType(new_evaluate, evaluator)
+    return evaluator

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -1,7 +1,7 @@
-import types
+import six
 
 
-def create_multi_node_evaluator(evaluator, communicator):
+def create_multi_node_evaluator(actual_evaluator, communicator):
     """Create a multi node evaluator from a normal evaluator.
 
     Actually patches the evaluator to work in multinode
@@ -10,7 +10,7 @@ def create_multi_node_evaluator(evaluator, communicator):
     work correctly in non-MPI environment.
 
     Args:
-        evaluator: evaluator to be patched
+        actual_evaluator: evaluator to be patched
             (e.g., ``chainer.training.extensions.Evaluator``)
         communicator: ChainerMN communicator
 
@@ -19,8 +19,8 @@ def create_multi_node_evaluator(evaluator, communicator):
 
     """
 
-    evaluator._mn_original_evaluate = evaluator.evaluate
-    evaluator._mn_communicator = communicator
+    actual_evaluator._mn_original_evaluate = actual_evaluator.evaluate
+    actual_evaluator._mn_communicator = communicator
 
     def new_evaluate(self):
         local_mean_dict = self._mn_original_evaluate()
@@ -32,5 +32,6 @@ def create_multi_node_evaluator(evaluator, communicator):
         }
         return global_mean_dict
 
-    evaluator.evaluate = types.MethodType(new_evaluate, evaluator)
-    return evaluator
+    actual_evaluator.evaluate = six.create_bound_method(
+        new_evaluate, actual_evaluator)
+    return actual_evaluator

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -15,7 +15,7 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
         communicator: ChainerMN communicator
 
     Returns:
-        The multi node evaluator based on ``evaluator``.
+        The multi-node patched ``actual_evaluator``.
 
     """
 


### PR DESCRIPTION
With Chainer #3952 current proxy implementation cannot handle
class attributes of Chainer's latest Evaluator.name, thus move
to just wrap the evaluate() method with multi-node support.

With this and #149 merged, ChainerMN will work with Chainer 4.0.

Note: consequence of this issue is, validation evaluator cannot have it's name `validation` and key `validation/main/loss` and `validation/main/accuracy` does not exist; which has two unexpected effects:

1. instead the evaluator overwrites `main/loss` and `main/accuracy`, printing no result in LogReport
2. due to the unexpected lack of `validation/main/loss` or accuracy user codes may fail (and following functionality such as saving actual models, might fail)