### PR TITLE
Move from nose to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,25 @@ os:
 
 python:
   - "2.7"
-  - "3.5.1"
+  - "3.5"
+  - "3.6"
 
 env:
-  - MPI="mpich-3.0.4"    CHAINER_VER="2.1.0"
   - MPI="mpich-3.0.4"    CHAINER_VER="3.1.0"
-  - MPI="mpich-3.2"      CHAINER_VER="2.1.0"
+  - MPI="mpich-3.0.4"    CHAINER_VER="3.2.0"
   - MPI="mpich-3.2"      CHAINER_VER="3.1.0"
-  - MPI="openmpi-1.6.5"  CHAINER_VER="2.1.0"
+  - MPI="mpich-3.2"      CHAINER_VER="3.2.0"
   - MPI="openmpi-1.6.5"  CHAINER_VER="3.1.0"
-  - MPI="openmpi-1.10.3" CHAINER_VER="2.1.0"
+  - MPI="openmpi-1.6.5"  CHAINER_VER="3.2.0"
   - MPI="openmpi-1.10.3" CHAINER_VER="3.1.0"
+  - MPI="openmpi-1.10.3" CHAINER_VER="3.2.0"
 
 cache:
   - pip
   - ccache
   - directories:
       $HOME/mpi
-      $HOME/.chaier
+      $HOME/.chainer
 
 before_install:
   - if [[ $TRAVIS_OS_NAME = "osx" ]]; then
@@ -40,7 +41,7 @@ before_install:
 
 install:
   - pip install -U pip wheel
-  - pip install nose hacking mock
+  - pip install pytest hacking mock
   - pip install autopep8
   - pip install cython mpi4py cffi
   - pip install chainer==${CHAINER_VER}
@@ -52,7 +53,7 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - export PYTHONWARNINGS='ignore::FutureWarning'
-  - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} nosetests -s -v -a '!nccl,!gpu,!slow' || exit $?; done)
+  - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} pytest -s -v -m 'not gpu and not slow' || exit $?; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop --no-nccl;
     fi

--- a/docs/source/installation/guide.rst
+++ b/docs/source/installation/guide.rst
@@ -99,7 +99,7 @@ We tested ChainerMN on all the following environments.
   * Ubuntu 14.04 LTS 64bit
 
 * Python 2.7.13 3.5.1 3.6.1
-* Chainer 2.0.2 2.1.0 3.0.0 3.1.0
+* Chainer 3.1.0 3.2.0
 * MPI
 
   * openmpi 1.6.5 1.10.3 2.1.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 install_requires = [
     'cffi',
-    'chainer >=1.23, !=2.0.0a1, !=2.0.0b1',
+    'chainer >=2.0.0',
     'cython',
     'mpi4py',
 ]
@@ -37,5 +37,6 @@ setup(
     packages=find_packages(),
     ext_modules=ext_modules,
     cmdclass={'build_ext': build_ext},
-    install_requires=install_requires
+    install_requires=install_requires,
+    test_requires=['pytest']
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 
 install_requires = [
     'cffi',
-    'chainer >=2.0.0',
+    'chainer >=3.0.0',
     'cython',
     'mpi4py',
 ]

--- a/tests/links_tests/test_batch_normalization.py
+++ b/tests/links_tests/test_batch_normalization.py
@@ -1,9 +1,7 @@
 import chainer
 import chainer.testing
-import chainer.testing.attr
 import chainer.utils
 import mpi4py.MPI
-import nose.plugins.skip
 import numpy
 import unittest
 
@@ -89,9 +87,6 @@ class TestMultiNodeBatchNormalization(unittest.TestCase):
         almost always different. Therefore, we also check that the results of
         (2) is different from them, to see that this test working correctly.
         """
-
-        if chainer.__version__.startswith('1.'):
-            raise nose.plugins.skip.SkipTest()
 
         comm = self.communicator
 

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -94,7 +94,7 @@ def create_communicator(param, use_gpu):
 
 def check_send_and_recv(communicator, *shape):
     if communicator.size < 2:
-        return  # skip
+        pytest.skip("This test is for multiple nodes")
 
     if communicator.rank > 0:
         rank_prev = (communicator.rank - 1) % communicator.size
@@ -111,7 +111,7 @@ def check_send_and_recv(communicator, *shape):
 
 def check_send_and_recv_tuple(communicator, data):
     if communicator.size < 2:
-        return  # skip
+        pytest.skip("This test is for multiple nodes")
 
     if communicator.rank > 0:
         rank_prev = (communicator.rank - 1) % communicator.size

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -1,14 +1,11 @@
-import unittest
-
 import mpi4py.MPI
-import nose.plugins.skip
 import numpy as np
+import pytest
 
 import chainer
 import chainer.cuda
 import chainer.links
 import chainer.testing
-import chainer.testing.attr
 from chainermn.communicators import _communication_utility
 from chainermn.communicators.flat_communicator \
     import FlatCommunicator
@@ -37,182 +34,166 @@ class ExampleModel(chainer.Chain):
         )
 
 
-@chainer.testing.parameterize(
+class Param(object):
+    def __init__(self, param):
+        self.gpu = False
+        self.nccl1 = False
+        self.__dict__.update(param)
+
+
+cpu_params = [Param(p) for p in [
     {
         'communicator_class': NaiveCommunicator,
-        'test_cpu': True,
-        'test_gpu': True,
+        'multi_node': True,
+    }]]
+gpu_params = [Param(p) for p in [
+    {
+        'communicator_class': NaiveCommunicator,
         'multi_node': True,
     }, {
         'communicator_class': FlatCommunicator,
-        'gpu': True,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': True,
     }, {
         'communicator_class': HierarchicalCommunicator,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': True,
-        'nccl': True,
     }, {
         'communicator_class': TwoDimensionalCommunicator,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': True,
-        'nccl': True,
     }, {
         'communicator_class': SingleNodeCommunicator,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': False,
-        'nccl': True,
     }, {
         'communicator_class': NonCudaAwareCommunicator,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': True,
-        'nccl': True,
     }, {
         'communicator_class': PureNcclCommunicator,
-        'test_cpu': False,
-        'test_gpu': True,
         'multi_node': True,
-        'nccl': True,
         'nccl1': False,
-    }
-)
-class TestCommunicator(unittest.TestCase):
+    }]]
 
-    def setUp(self):
-        self.mpi_comm = mpi4py.MPI.COMM_WORLD
+mpi_comm = mpi4py.MPI.COMM_WORLD
 
-        if not self.multi_node:
-            ranks = _communication_utility.init_ranks(self.mpi_comm)
-            inter_size = ranks[4]
-            if inter_size > 1:
-                raise nose.plugins.skip.SkipTest()
-        if hasattr(self, 'nccl1') and not self.nccl1 \
-           and nccl.get_version() < 2000:
-            raise nose.plugins.skip.SkipTest()
 
-        self.communicator = self.communicator_class(self.mpi_comm)
+def create_communicator(param, use_gpu):
+    if not param.multi_node:
+        ranks = _communication_utility.init_ranks(mpi_comm)
+        inter_size = ranks[4]
+        if inter_size > 1:
+            pytest.skip('This test is for single node only')
 
-        if hasattr(self.communicator, 'intra_rank'):
-            chainer.cuda.get_device(self.communicator.intra_rank).use()
+    if use_gpu and not param.nccl1 and nccl.get_version() < 2000:
+        pytest.skip('This test requires NCCL version >= 2.0')
 
-    def test_rank(self):
-        self.assertEqual(self.communicator.rank,
-                         self.mpi_comm.Get_rank())
+    communicator = param.communicator_class(mpi_comm)
 
-    def test_size(self):
-        self.assertEqual(self.communicator.size,
-                         self.mpi_comm.Get_size())
+    if hasattr(communicator, 'intra_rank'):
+        chainer.cuda.get_device(communicator.intra_rank).use()
 
-    def check_send_and_recv(self, *shape):
-        if self.communicator.size < 2:
-            raise nose.plugins.skip.SkipTest()
+    return communicator
 
-        if self.communicator.rank > 0:
-            rank_prev = (self.communicator.rank - 1) % self.communicator.size
-            data_recv = self.communicator.recv(source=rank_prev, tag=0)
-            chainer.testing.assert_allclose(
-                data_recv, rank_prev * np.ones((shape)))
 
-        if self.communicator.rank < self.communicator.size - 1:
-            rank_next = (self.communicator.rank + 1) % self.communicator.size
-            data_send = self.communicator.rank * \
-                np.ones((shape)).astype(np.float32)
-            self.communicator.send(data_send, dest=rank_next, tag=0)
+def check_send_and_recv(communicator, *shape):
+    if communicator.size < 2:
+        return  # skip
 
-    def test_send_and_recv1(self):
-        self.check_send_and_recv(50)
+    if communicator.rank > 0:
+        rank_prev = (communicator.rank - 1) % communicator.size
+        data_recv = communicator.recv(source=rank_prev, tag=0)
+        chainer.testing.assert_allclose(
+            data_recv, rank_prev * np.ones((shape)))
 
-    def test_send_and_recv2(self):
-        self.check_send_and_recv(50, 20)
+    if communicator.rank < communicator.size - 1:
+        rank_next = (communicator.rank + 1) % communicator.size
+        data_send = communicator.rank * \
+            np.ones((shape)).astype(np.float32)
+        communicator.send(data_send, dest=rank_next, tag=0)
 
-    def test_send_and_recv3(self):
-        self.check_send_and_recv(50, 20, 5)
 
-    def test_send_and_recv4(self):
-        self.check_send_and_recv(50, 20, 5, 3)
+def check_send_and_recv_tuple(communicator, data):
+    if communicator.size < 2:
+        return  # skip
 
-    def check_send_and_recv_tuple(self, data):
-        if self.communicator.size < 2:
-            raise nose.plugins.skip.SkipTest()
+    if communicator.rank > 0:
+        rank_prev = (communicator.rank - 1) % communicator.size
+        data_recv = communicator.recv(source=rank_prev, tag=0)
+        for array0, array1 in zip(data, data_recv):
+            chainer.testing.assert_allclose(array0, array1)
 
-        if self.communicator.rank > 0:
-            rank_prev = (self.communicator.rank - 1) % self.communicator.size
-            data_recv = self.communicator.recv(source=rank_prev, tag=0)
-            for array0, array1 in zip(data, data_recv):
-                chainer.testing.assert_allclose(array0, array1)
+    if communicator.rank < communicator.size - 1:
+        rank_next = (communicator.rank + 1) % communicator.size
+        communicator.send(data, dest=rank_next, tag=0)
 
-        if self.communicator.rank < self.communicator.size - 1:
-            rank_next = (self.communicator.rank + 1) % self.communicator.size
-            self.communicator.send(data, dest=rank_next, tag=0)
 
-    def test_send_and_recv5(self):
-        data = [np.ones((50)).astype(np.float32)]
-        self.check_send_and_recv_tuple(data)
+def check_broadcast_data_0(communicator, model):
+    model.a.W.data[:] = communicator.rank
+    model.b.W.data[:] = communicator.rank + 1
+    model.c.b.data[:] = communicator.rank + 2
+    communicator.broadcast_data(model)
+    chainer.testing.assert_allclose(model.a.W.data, 0 * np.ones((3, 2)))
+    chainer.testing.assert_allclose(model.b.W.data, 1 * np.ones((4, 3)))
+    chainer.testing.assert_allclose(model.c.b.data, 2 * np.ones((5, )))
 
-    def test_send_and_recv6(self):
-        data = [
-            np.ones((50)).astype(np.float32),
-            np.ones((50, 20)).astype(np.float32),
-            np.ones((50, 20, 5)).astype(np.float32)]
-        self.check_send_and_recv_tuple(data)
 
-    def check_broadcast_data(self, model):
-        model.a.W.data[:] = self.communicator.rank
-        model.b.W.data[:] = self.communicator.rank + 1
-        model.c.b.data[:] = self.communicator.rank + 2
-        self.communicator.broadcast_data(model)
-        chainer.testing.assert_allclose(model.a.W.data, 0 * np.ones((3, 2)))
-        chainer.testing.assert_allclose(model.b.W.data, 1 * np.ones((4, 3)))
-        chainer.testing.assert_allclose(model.c.b.data, 2 * np.ones((5, )))
+def check_allreduce_grad(communicator, model):
+    # We need to repeat twice for regressions on lazy initialization of
+    # sub communicators.
+    for _ in range(2):
+        model.a.W.grad[:] = communicator.rank
+        model.b.W.grad[:] = communicator.rank + 1
+        model.c.b.grad[:] = communicator.rank + 2
 
-    def check_allreduce_grad(self, model):
-        # We need to repeat twice for regressions on lazy initialization of
-        # sub communicators.
-        for _ in range(2):
-            model.a.W.grad[:] = self.communicator.rank
-            model.b.W.grad[:] = self.communicator.rank + 1
-            model.c.b.grad[:] = self.communicator.rank + 2
+        communicator.allreduce_grad(model)
+        base = (communicator.size - 1.0) / 2
 
-            self.communicator.allreduce_grad(model)
-            base = (self.communicator.size - 1.0) / 2
+        chainer.testing.assert_allclose(model.a.W.grad,
+                                        (base + 0) * np.ones((3, 2)))
+        chainer.testing.assert_allclose(model.b.W.grad,
+                                        (base + 1) * np.ones((4, 3)))
+        chainer.testing.assert_allclose(model.c.b.grad,
+                                        (base + 2) * np.ones((5, )))
 
-            chainer.testing.assert_allclose(model.a.W.grad,
-                                            (base + 0) * np.ones((3, 2)))
-            chainer.testing.assert_allclose(model.b.W.grad,
-                                            (base + 1) * np.ones((4, 3)))
-            chainer.testing.assert_allclose(model.c.b.grad,
-                                            (base + 2) * np.ones((5, )))
 
-    def test_broadcast_data_cpu(self):
-        if not self.test_cpu:
-            raise nose.plugins.skip.SkipTest()
-        model = ExampleModel()
-        self.check_broadcast_data(model)
+def check_send_recv(param, use_gpu):
+    communicator = create_communicator(param, use_gpu)
 
-    @chainer.testing.attr.gpu
-    def test_broadcast_data_gpu(self):
-        if not self.test_gpu:
-            raise nose.plugins.skip.SkipTest()
-        model = ExampleModel()
+    assert mpi_comm.Get_rank() == communicator.rank
+    assert mpi_comm.Get_size() == communicator.size
+
+    check_send_and_recv(communicator, 50)
+    check_send_and_recv(communicator, 50, 20)
+
+    check_send_and_recv(communicator, 50, 20, 5)
+    check_send_and_recv(communicator, 50, 20, 5, 3)
+
+    data = [np.ones((50)).astype(np.float32)]
+    check_send_and_recv_tuple(communicator, data)
+
+    data = [
+        np.ones((50)).astype(np.float32),
+        np.ones((50, 20)).astype(np.float32),
+        np.ones((50, 20, 5)).astype(np.float32)]
+    check_send_and_recv_tuple(communicator, data)
+
+
+def check_broadcast_data(param, use_gpu):
+    communicator = create_communicator(param, use_gpu)
+
+    model = ExampleModel()
+    if use_gpu:
         model.to_gpu()
-        self.check_broadcast_data(model)
+    check_broadcast_data_0(communicator, model)
+    check_allreduce_grad(communicator, model)
 
-    def test_allreduce_grad_cpu(self):
-        if not self.test_cpu:
-            raise nose.plugins.skip.SkipTest()
-        model = ExampleModel()
-        self.check_allreduce_grad(model)
 
-    @chainer.testing.attr.gpu
-    def test_allreduce_grad_gpu(self):
-        if not self.test_gpu:
-            raise nose.plugins.skip.SkipTest()
-        model = ExampleModel()
-        model.to_gpu()
-        self.check_allreduce_grad(model)
+# chainer.testing.parameterize is not available at functions
+@pytest.mark.parametrize('param', cpu_params)
+def test_communicator_cpu(param):
+    check_send_recv(param, False)
+    check_broadcast_data(param, False)
+
+
+@pytest.mark.parametrize('param', gpu_params)
+@chainer.testing.attr.gpu
+def test_communicator_gpu(param):
+    check_send_recv(param, True)
+    check_broadcast_data(param, True)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -99,8 +99,6 @@ def test_scatter_large_dataset_naive():
 
     scatter_large_data(communicator)
 
-# FlatCommunicator requires GPU, not NCCL
-
 
 @testing.attr.gpu
 @testing.attr.slow

--- a/tests/test_node_aware_communicator_base.py
+++ b/tests/test_node_aware_communicator_base.py
@@ -1,8 +1,9 @@
 import collections
-import mpi4py.MPI
-import nose.plugins.skip
 import os
 import unittest
+
+import mpi4py.MPI
+import pytest
 
 from chainermn.communicators import _base
 
@@ -20,7 +21,7 @@ class TestNodeAwareCommunicatorBase(unittest.TestCase):
         elif 'OMPI_COMM_WORLD_LOCAL_RANK' in os.environ:  # OpenMPI
             expected = int(os.environ['OMPI_COMM_WORLD_LOCAL_RANK'])
         else:
-            raise nose.plugins.skip.SkipTest
+            pytest.skip('No MPI specified')
 
         self.assertEqual(self.communicator.intra_rank, expected)
 
@@ -30,7 +31,7 @@ class TestNodeAwareCommunicatorBase(unittest.TestCase):
         elif 'OMPI_COMM_WORLD_LOCAL_SIZE' in os.environ:  # OpenMPI
             expected = int(os.environ['OMPI_COMM_WORLD_LOCAL_RANK'])
         else:
-            raise nose.plugins.skip.SkipTest
+            pytest.skip('No MPI specified')
 
         self.assertEqual(self.communicator.intra_rank, expected)
 


### PR DESCRIPTION
- Chainer has moved to pytest since 3.0.0 and now MN follows.  An
  example of testing tool mismatch is: Chainer's parameterized test
  started checking all Exceptions including nose SkipTest(), at #3963
  and #3876 which are included in 3.2.0 and 4.0, and all unit tests
  that skips is recognized as test failure. Additionally, this patch
  starts supporting Chainer 3.2.0 and 2.1.0, dropping 1.x as well (One
  more issue to support 4.0 remains).
- Remove `nccl` selector on running unit tests and all merged to
  `gpu`, as ChainerMN requires NCCL by default.
- Also, mixture of chainer.testing.attr.gpu and
  chainer.testing.parameterize, with passing pytest to `-m 'not gpu'`
  does not work in pytest because nose's attributes are direct
  attribute to test object or function, in contrast to pytest. Thus
  this patch dissolves all parametrized tests that is using `{gpu:
  True}, {gpu: False}` or `{nccl: True}, {nccl: False}` as parameters,
  which is replaced by simple function call patterns with
  `@chainer.testing.attr.gpu` .
- Add Python 3.6 as test target in Travis.
- Fix test_scatter_large_dataset not working for flat communicator.
- Drop Chainer 2.1 and add 3.1 to CI as tested version.
- Fix MNist data download was not cached at Travis CI.