### PR TITLE
Add intra_rank to all communicators

### DIFF
--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -242,4 +242,3 @@ class CommunicatorBase(object):
         self.inter_mpi_comm = comms[1]
         if self.use_nccl:
             self.intra_nccl_comm = comms[2]
-

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -18,8 +18,9 @@ def init_ranks(mpi_comm):
                 * intra_rank (rank within the local computing node)
                 * intra_size (number of processes on the node)
                 * inter_rank (rank of the node)
-                * inter_size (number of computing nodes)"""
-    
+                * inter_size (number of computing nodes)
+    """
+
     global_names = mpi_comm.gather(mpi4py.MPI.Get_processor_name())
 
     if mpi_comm.rank == 0:

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -5,6 +5,21 @@ from chainermn.communicators import _memory_utility
 
 
 def init_ranks(mpi_comm):
+    """Returns rank information of the local process in `mpi_comm`.
+
+    Args:
+        mpi_comm (type:TODO)
+                 MPI Communicator from mpi4py
+
+    Returns:
+        rank_info (list):
+            Elements are:
+                * rank (`mpi_comm.rank`)
+                * intra_rank (rank within the local computing node)
+                * intra_size (number of processes on the node)
+                * inter_rank (rank of the node)
+                * inter_size (number of computing nodes)"""
+    
     global_names = mpi_comm.gather(mpi4py.MPI.Get_processor_name())
 
     if mpi_comm.rank == 0:

--- a/chainermn/communicators/dummy_communicator.py
+++ b/chainermn/communicators/dummy_communicator.py
@@ -3,7 +3,7 @@ from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
 
 
-class DummyCommunicator(_base.NodeAwareCommunicatorBase):
+class DummyCommunicator(_base.CommunicatorBase):
 
     """Dummy communicator that does not communicate at all.
 

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -5,7 +5,7 @@ from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
 
 
-class FlatCommunicator(_base.NodeAwareCommunicatorBase):
+class FlatCommunicator(_base.CommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(FlatCommunicator, self).__init__(mpi_comm, False)

--- a/chainermn/communicators/hierarchical_communicator.py
+++ b/chainermn/communicators/hierarchical_communicator.py
@@ -7,7 +7,7 @@ from chainermn.communicators import _memory_utility
 from chainermn import nccl
 
 
-class HierarchicalCommunicator(_base.NodeAwareCommunicatorBase):
+class HierarchicalCommunicator(_base.CommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(HierarchicalCommunicator, self).__init__(mpi_comm, use_nccl=True)

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -7,7 +7,7 @@ from chainermn.communicators import _memory_utility
 from chainermn import nccl
 
 
-class NonCudaAwareCommunicator(_base.NodeAwareCommunicatorBase):
+class NonCudaAwareCommunicator(_base.CommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(NonCudaAwareCommunicator, self).__init__(mpi_comm, use_nccl=True)

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -13,7 +13,7 @@ class PureNcclCommunicator(_base.CommunicatorBase):
             raise RuntimeError(
                 'PureNcclCommunicator is only supported on NCCL 2.0+')
 
-        super(PureNcclCommunicator, self).__init__(mpi_comm)
+        super(PureNcclCommunicator, self).__init__(mpi_comm, True)
         self._init_ranks()
 
         self.inter_mpi_comm = None

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -5,7 +5,7 @@ from chainermn.communicators import _memory_utility
 from chainermn import nccl
 
 
-class SingleNodeCommunicator(_base.NodeAwareCommunicatorBase):
+class SingleNodeCommunicator(_base.CommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(SingleNodeCommunicator, self).__init__(mpi_comm, use_nccl=True)

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -8,7 +8,7 @@ from chainermn.communicators import _memory_utility
 from chainermn import nccl
 
 
-class TwoDimensionalCommunicator(_base.NodeAwareCommunicatorBase):
+class TwoDimensionalCommunicator(_base.CommunicatorBase):
 
     def __init__(self, mpi_comm=mpi4py.MPI.COMM_WORLD):
         super(TwoDimensionalCommunicator, self).__init__(

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -86,7 +86,7 @@ def create_communicator(param, use_gpu):
 
     communicator = param.communicator_class(mpi_comm)
 
-    if hasattr(communicator, 'intra_rank'):
+    if use_gpu:
         chainer.cuda.get_device(communicator.intra_rank).use()
 
     return communicator

--- a/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
+++ b/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
@@ -40,6 +40,9 @@ class TestCommunicatorBase(unittest.TestCase):
             self.communicator.inter_rank, self.communicator.inter_size))
 
         if self.mpi_comm.rank == 0:
+            for inter_rank, inter_size in ranks_and_sizes:
+                self.assertTrue(0 <= inter_rank < inter_size)
+
             sizes = list(set(x[1] for x in ranks_and_sizes))
             self.assertEqual(len(sizes), 1)
             size = sizes[0]
@@ -53,6 +56,9 @@ class TestCommunicatorBase(unittest.TestCase):
             self.communicator.inter_rank, self.communicator.inter_size))
 
         if self.mpi_comm.rank == 0:
+            for intra_rank, intra_size, _, _ in ranks_and_sizes:
+                self.assertTrue(0 <= intra_rank < intra_size)
+
             inter_rank_to_intra_ranks = collections.defaultdict(list)
 
             for intra_rank, _, inter_rank, _ in ranks_and_sizes:

--- a/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
+++ b/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
@@ -8,11 +8,11 @@ import pytest
 from chainermn.communicators import _base
 
 
-class TestNodeAwareCommunicatorBase(unittest.TestCase):
+class TestCommunicatorBase(unittest.TestCase):
 
     def setUp(self):
         self.mpi_comm = mpi4py.MPI.COMM_WORLD
-        self.communicator = _base.NodeAwareCommunicatorBase(
+        self.communicator = _base.CommunicatorBase(
             self.mpi_comm, use_nccl=False)
 
     def test_intra_rank_with_env(self):


### PR DESCRIPTION
In the current communicator class hierarchy, not all communicator have `intra_rank` attribute due to a historical reason.
The attribute is currently used to determine if ChainerMN is using GPUs because `intra_rank` was implemented to determine GPUs to use in a local physical node. However, GPU ID and `intra_rank` are different concepts and the usage is inappropriate.

This PR merges`NodeAwareCommunicator` into `CommunicatorBase` so `CommunicatorBase` class and all of its ancestors have `intra_rank` attribute.