### PR TITLE
Fix importing errors in unit tests 

### DIFF
--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -7,6 +7,7 @@ import tempfile
 import chainer
 import chainer.functions as F
 import chainer.links as L
+import chainer.testing
 from chainer import training
 from chainer.training import extensions
 

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -1,4 +1,5 @@
 import chainer
+import chainer.testing
 import numpy
 import pytest
 

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -2,6 +2,7 @@ import copy
 import functools
 
 import chainer
+import chainer.testing
 import numpy
 import pytest
 


### PR DESCRIPTION
Some tests lack `import chainer.testing`, so the produce the following error when invoked alone by `pytest`.

```
./tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
============================= test session starts ==============================
platform linux -- Python 3.6.0, pytest-3.0.5, py-1.4.32, pluggy-0.4.0 -- /home/kfukuda/.pyenv/versions/anaconda3-4.3.1/bin/python
cachedir: .cache
rootdir: /home/kfukuda/chainermn, inifile:
collecting ... collected 0 items / 1 errors

==================================== ERRORS ====================================
 ERROR collecting tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
tests/chainermn_tests/functions_tests/test_point_to_point_communication.py:170: in <module>
    @chainer.testing.attr.gpu
E   AttributeError: module 'chainer' has no attribute 'testing'
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
=========================== 1 error in 1.42 seconds ============================

```

This PR fixes these issues simply by adding `import chainer.testing` .