### PR TITLE
Add reference of ChainerMN paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ Please refer to [Chainer Contribution Guide](http://docs.chainer.org/en/latest/c
 ## License
 
 [MIT License](LICENSE)
+
+## Reference
+
+Akiba, T., Fukuda, K. and Suzuki, S.,
+ChainerMN: Scalable Distributed Deep Learning Framework,
+*Proceedings of Workshop on ML Systems in
+The thirty-first Annual Conference on Neural Information Processing Systems (NIPS)*, (2017)
+[URL](http://learningsys.org/nips17/assets/papers/paper_25.pdf), [BibTex](chainermn_bibtex.txt)

--- a/chainermn_bibtex.txt
+++ b/chainermn_bibtex.txt
@@ -1,0 +1,7 @@
+@inproceedings{chainermn_mlsys2017,
+author = {Akiba, Takuya and Fukuda, Keisuke and Suzuki, Shuji},
+title = {{ChainerMN: Scalable Distributed Deep Learning Framework}},
+booktitle = {Proceedings of Workshop on ML Systems in The thirty-first Annual Conference on Neural Information Processing Systems (NIPS)},
+year = {2017}
+url = {http://learningsys.org/nips17/assets/papers/paper_25.pdf},
+}


### PR DESCRIPTION
I add the reference of ChainerMN paper which was accepted in the workshop ML Systems at NIP S2017.