### PR TITLE
[WIP] Supress redundant test check status reports caused by MPI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+_mpi_rank = (os.environ.get('MV2_COMM_WORLD_RANK') or
+             os.environ.get('OMPI_COMM_WORLD_RANK'))
+
+if _mpi_rank is None:
+    _print_report = True
+else:
+    if int(_mpi_rank) == 0:
+        _print_report = True
+    else:
+        _print_report = False
+
+def pytest_configure(config):
+    if not _print_report:
+        config.option.verbose = -1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ else:
     else:
         _print_report = False
 
+
 def pytest_configure(config):
     if not _print_report:
         config.option.verbose = -1


### PR DESCRIPTION
When the `pytest` command is run, status reports of each test are printed from all processes.
```
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param2]
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param2] collected 116 items

tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param2] PASSEDPASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param3] PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param3] PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param3]
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param3] PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param5] PASSEDPASSEDPASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param5]
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param5]
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param5] PASSEDPASSEDPASSEDPASSED
```

They are redundant and makes it hard to read test results.

This PR adds an in-directory `pytest` plugin (which is `tests/conftest.py`) and supress status reports from non-zero MPI ranks, so the test output is cleaner as follows:
```
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param2] ...PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param3] ...PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param5] ...PASSED
tests/chainermn_tests/communicator_tests/test_communicator.py::test_communicator_gpu[param0] ...PASSED
```
