### PR TITLE
Adds test for Chainer 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ python:
   - "3.6"
 
 env:
-  - MPI="mpich-3.0.4"    CHAINER_VER="3.1.0"
   - MPI="mpich-3.0.4"    CHAINER_VER="3.2.0"
-  - MPI="mpich-3.2"      CHAINER_VER="3.1.0"
+  - MPI="mpich-3.0.4"    CHAINER_VER="3.3.0"
   - MPI="mpich-3.2"      CHAINER_VER="3.2.0"
-  - MPI="openmpi-1.6.5"  CHAINER_VER="3.1.0"
+  - MPI="mpich-3.2"      CHAINER_VER="3.3.0"
   - MPI="openmpi-1.6.5"  CHAINER_VER="3.2.0"
-  - MPI="openmpi-1.10.3" CHAINER_VER="3.1.0"
+  - MPI="openmpi-1.6.5"  CHAINER_VER="3.3.0"
   - MPI="openmpi-1.10.3" CHAINER_VER="3.2.0"
+  - MPI="openmpi-1.10.3" CHAINER_VER="3.3.0"
 
 cache:
   - pip


### PR DESCRIPTION
Chainer 3.3 has been released.
This PR adds Chainer 3.3 to the Travis CI test matrix.
To keep CI time short, it drops Chainer 3.1 tests.