### PR TITLE
Fix bugs in DoubleBufferingOptimizer and PureNcclCommunicator

### DIFF
--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -63,6 +63,8 @@ class PureNcclCommunicator(_base.CommunicatorBase):
         self.gpu_buffer_b.assign(n_bytes)
         _memory_utility.pack_params(
             params, itemsize, 'grad', self.gpu_buffer_a)
+        if stream != chainer.cuda.Stream.null:
+            chainer.cuda.Stream.null.synchronize()
         self.nccl_comm.allReduce(self.gpu_buffer_a.ptr(),
                                  self.gpu_buffer_b.ptr(), n_elems,
                                  nccl.NCCL_FLOAT, nccl.NCCL_SUM,

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -97,6 +97,8 @@ class _DoubleBufferingOptimizer(object):
                 'target_params_list', [
                     list(sorted(self.target.namedparams())),
                     list(sorted(self.communicated_target.namedparams()))])
+            super(_DoubleBufferingOptimizer, self).__setattr__(
+                    'needs_update', False)
         else:
             self.wait()
             self.swap_grad(self.target_params_list[0],

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -98,7 +98,7 @@ class _DoubleBufferingOptimizer(object):
                     list(sorted(self.target.namedparams())),
                     list(sorted(self.communicated_target.namedparams()))])
             super(_DoubleBufferingOptimizer, self).__setattr__(
-                    'needs_update', False)
+                'needs_update', False)
         else:
             self.wait()
             self.swap_grad(self.target_params_list[0],

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -152,7 +152,6 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
             self.optimizer.communicated_target.b.W.grad,
             (base + 4) * np.ones((4, 3)))
 
-
         with self.target.init_scope():
             c = chainer.links.Linear(4, 4)
             c.to_gpu()
@@ -186,7 +185,7 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
             self.optimizer.communicated_target.c.W.grad,
             (base + 8) * np.ones((4, 4)))
 
-        self.optimizer.target.a.W.grad[:] = self.comm.rank + 9 
+        self.optimizer.target.a.W.grad[:] = self.comm.rank + 9
         self.optimizer.target.b.W.grad[:] = self.comm.rank + 10
         self.optimizer.target.c.W.grad[:] = self.comm.rank + 11
         self.optimizer.update()


### PR DESCRIPTION
I fixed bugs in DoubleBufferingOptimizer and PureNcclCommunicator.
Current double buffering feature has two bugs.

1. runs actual_optimizer.update() when it is not required. This bug occurs when model is changed dynamically.
2. doesn't wait for GPU process on default stream after pack_params.
 
I fixed them.