### PR TITLE
Check contiguousness of outgoing arrays

### DIFF
--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -103,7 +103,7 @@ def unpack_params(params, itemsize, attr_name, buffer):
 
 def array_to_buffer_object(array):
     xp = chainer.cuda.get_array_module(array)
-    array = xp.require(array, dtype=xp.float32, requirements=['C_CONTIGUOUS'])
+    array = xp.ascontiguousarray(array)
 
     if xp is np:
         return array

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -102,7 +102,10 @@ def unpack_params(params, itemsize, attr_name, buffer):
 
 
 def array_to_buffer_object(array):
-    if chainer.cuda.get_array_module(array) is np:
+    xp = chainer.cuda.get_array_module(array)
+    array = xp.require(array, dtype=xp.float32, requirements=['C_CONTIGUOUS'])
+
+    if xp is np:
         return array
     else:
         ffi = cffi.FFI()


### PR DESCRIPTION
If an input array is not C-contiguous nor Fortran-contiguous, `MPI_Ssend` will fail.