### PR TITLE
Fix MultiNodeNStepRNN to use Chainer n_cells

### DIFF
--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -1,16 +1,21 @@
 import chainer
-import chainer.functions.connection as conn
+import chainer.functions.connection as fconn
+import chainer.links.connection as lconn
 import chainermn.functions
 
 
-_rnn_n_cells = {
-    conn.n_step_gru.n_step_bigru: 1,
-    conn.n_step_gru.n_step_gru: 1,
-    conn.n_step_lstm.n_step_bilstm: 2,
-    conn.n_step_lstm.n_step_lstm: 2,
-    conn.n_step_rnn.n_step_birnn: 1,
-    conn.n_step_rnn.n_step_rnn: 1,
-}
+# Chainer <=v3
+CHAINER_VERSION_OLD_RNN = (int(chainer.__version__.split('.')[0]) <= 3)
+
+if CHAINER_VERSION_OLD_RNN:
+    _rnn_n_cells = {
+        fconn.n_step_gru.n_step_bigru: 1,
+        fconn.n_step_gru.n_step_gru: 1,
+        fconn.n_step_lstm.n_step_bilstm: 2,
+        fconn.n_step_lstm.n_step_lstm: 2,
+        fconn.n_step_rnn.n_step_birnn: 1,
+        fconn.n_step_rnn.n_step_rnn: 1,
+    }
 
 
 class _MultiNodeNStepRNN(chainer.Chain):
@@ -22,10 +27,21 @@ class _MultiNodeNStepRNN(chainer.Chain):
         self.rank_in = rank_in
         self.rank_out = rank_out
 
-        if not hasattr(link, 'rnn') or link.rnn not in _rnn_n_cells:
-            raise ValueError('link must be NStepRNN and its inherited link')
-        else:
-            self.n_cells = _rnn_n_cells[link.rnn]
+        if CHAINER_VERSION_OLD_RNN:
+            if not hasattr(link, 'rnn') or link.rnn not in _rnn_n_cells:
+                raise ValueError(
+                    'link must be NStepRNN and its inherited link')
+            else:
+                self.n_cells = _rnn_n_cells[link.rnn]
+
+        else:  # expect Chainer >4.0.0b3
+            check_lstm = issubclass(
+                link.__class__, lconn.n_step_rnn.NStepRNNBase)
+            if not check_lstm:
+                raise ValueError(
+                    'link must be NStepRNN and its inherited link')
+            else:
+                self.n_cells = link.n_cells
 
     def __call__(self, *inputs):
         cells = [None for _ in range(self.n_cells)]


### PR DESCRIPTION
This PR replaces #205.

## observed issue

In Chainer >4.0.0b3, internal structures of `n_step_rnn` has been drastically changed.
Thus we cannot retrieve the number of internal cells of RNN in a simple way.

## approach

I created PR chainer/chainer#4417, considering maintenancability to keep backward compatibility, to add `n_cells` property to `n_step_rnn` family.
This PR simply uses them to rewrite `MultiNodeNStepRNN`, based on #205.