### PR TITLE
Fix bcast

### DIFF
--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -58,7 +58,12 @@ class TestCollectiveCommunication(unittest.TestCase):
 
     def check_bcast(self, x):
         root = 0
-        y = chainermn.functions.bcast(self.communicator, x, root, self.device)
+        if self.communicator.rank == root:
+            y = chainermn.functions.bcast(
+                self.communicator, x, root, self.device)
+        else:
+            y = chainermn.functions.bcast(
+                self.communicator, None, root, self.device)
         e = chainer.functions.mean_squared_error(y, x)
         e.backward()
 


### PR DESCRIPTION
## Problem

`chainermn.functions.bcast` fails when `None` is passed as slave inputs.

## Solution

Add a dummy variable for `Bcast.forward`, like `chainermn.functions.{recv,gather}`.