### PR TITLE
Clean up Communicator interface with changes

### DIFF
--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -50,8 +50,8 @@ class CommunicatorBase(object):
     def gather(self, data, root=0):
         raise NotImplementedError()
 
-    def allreduce(self, data):
-        raise NotImplementedError()
+    # TODO(kuenishi) implment ``allreduce``
+    # def allreduce(self, xs):
 
     # on objects
     def send_obj(self, obj, dest, tag):
@@ -66,7 +66,8 @@ class CommunicatorBase(object):
     def gather_obj(self, data, root=0):
         raise NotImplementedError()
 
-    def allreduce_obj(self, model, op=None):
+    # We may add ``op`` argument in future when needed.
+    def allreduce_obj(self, obj):
         raise NotImplementedError()
 
     # Special communication method on grads and data of models
@@ -74,14 +75,8 @@ class CommunicatorBase(object):
         '''Broadcast Chainer model data'''
         raise NotImplementedError()
 
-    def broadcast_data(self, model, max_buf_len=None, root=0):
-        '''Broadcast Chainer model data
-
-        Left for backward compatibility, but will be removed in future
-        versions. Use bcast_data() method instead.
-
-        '''
-        raise NotImplementedError()
+    # Will be deprecated in some future
+    broadcast_data = bcast_data
 
     def allreduce_grad(self, model):
         raise NotImplementedError()

--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -1,351 +1,87 @@
-import collections
-
-import mpi4py
-import numpy
-
-import chainer.cuda
-import chainer.utils
-from chainermn.communicators import _communication_utility
-from chainermn.communicators import _memory_utility
-from chainermn import nccl
-
-
-def _cnt_to_dsp(cnt):
-    """Utility to convert length array to cumulative array."""
-    return [0] + numpy.cumsum(cnt)[:-1].tolist()
-
-
-class _MessageType(object):
-
-    def __init__(self, obj):
-        if isinstance(obj, numpy.ndarray) \
-                or chainer.cuda.get_array_module(obj) is not numpy:
-            self.is_tuple = False
-            self.narr = 1
-            self.ndims = [obj.ndim]
-            self.shapes = [obj.shape]
-        elif isinstance(obj, collections.Iterable):
-            self.is_tuple = True
-            self.narr = len(obj)
-            self.ndims = [x.ndim for x in obj]
-            self.shapes = [x.shape for x in obj]
-        else:
-            raise ValueError(
-                'Message object must be numpy/cupy array or tuple.')
 
 
 class CommunicatorBase(object):
+    '''\
 
-    def __init__(self, mpi_comm, use_nccl=False):
-        self.mpi_comm = mpi_comm
-        self._init_ranks()
+    Naming conventions of data transfer methods:
+    * Methods that treats Python objects have ``_obj`` suffix
+    * Methods that treats Chainer Models have suffix ``_grad``
+    * Methods that treats ndarray, or such list have no suffix
 
-        if use_nccl and not nccl._available:
-            raise RuntimeError(
-                'NCCL is not available. '
-                'Please confirm that NCCL is enabled in CuPy.'
-            )
+    So the number of methods would be::
 
-        self.use_nccl = use_nccl
+        [send, recv, bcast, gather, allreduce] * [ '_obj', '']
 
-        # We have to delay the initialization of communicators. This is because
-        # NCCL's communicators use the current CUDA devices at the time of
-        # initialization. Therefore, we have to initialize NCCL communicators
-        # after users set the devices to use.
-        self.inter_mpi_comm = None
-        self.intra_mpi_comm = None
-        if self.use_nccl:
-            self.intra_nccl_comm = None
+    (with single exception ``alltoall`` and ``split``,
+    ``allreduce_grad`` and ``bcast_data`` so far). Also methods
+    are supposed to be written in this order. Methods may also be
+    allowed to be left uninmplemented.
+
+    '''
 
     @property
     def rank(self):
-        return self.mpi_comm.rank
+        raise NotImplementedError()
+
+    @property
+    def intra_rank(self):
+        raise NotImplementedError()
 
     @property
     def size(self):
-        return self.mpi_comm.size
+        raise NotImplementedError()
 
     def split(self, color, key):
-        """A wrapper function of MPI_Comm_Split.
-
-        This method splits the inter MPI commnicator and return a wrapped
-        ChainerMN communicator.
-
-        Args:
-            color (int):
-                Index of new group. The process with the same color will be
-                assigned to the same group.
-            key (int):
-                Control of rank assignment. The process will be assigned
-                a rank in the new group ordered by the value of key.
-                If you do not care of the rank, you can just simply specify
-                the original rank.
-
-        Returns:
-            CommunicatorBase
-        """
-        return self.__class__(mpi_comm=self.mpi_comm.Split(color, key))
-
-    def send(self, obj, dest, tag):
-        """A primitive for inter-process transmitter.
-
-        This method sends numpy-array to target process.
-        The target process is expected to invoke ``recv()``.
-        This method relies on mpi4py fast communication optimized for
-        numpy arrays, which discards any information attached to
-        chainer.Variable objects. Please be sure.
-
-        Args:
-            obj: data to be sent (tuple, list or raw numpy/cupy array)
-            dest (int): Target process specifier.
-            tag (int): Message ID (MPI feature).
-
-        """
-        chainer.utils.experimental(
-            'chainermn.communicators.CommunicatorBase.send')
-
-        msgtype = _MessageType(obj)
-        """We use ssend() instead of send() to pass unittests.
-        If we don't use it, an error occurs in
-        test_point_to_point_communication.py
-        when using MVAPICH2-2.2 and GPUs.
-        """
-        self.mpi_comm.ssend(msgtype, dest=dest, tag=tag)
-
-        # Type check.
-        if not msgtype.is_tuple:
-            obj = [obj]
-
-        for x in obj:
-            if x.dtype != numpy.float32:
-                raise ValueError('send only support dtype == numpy.float32')
-
-        for array in obj:
-            if chainer.cuda.get_array_module(array) is not numpy:
-                chainer.cuda.Stream.null.synchronize()
-
-            buf = _memory_utility.array_to_buffer_object(array)
-            """We use Ssend() for the same reason as using ssend()."""
-            self.mpi_comm.Ssend(buf, dest=dest, tag=tag)
-
-    def recv(self, source, tag):
-        """A primitive of inter-process receiver.
-
-        This method tries to receive numpy-array from target process.
-        The target process is expected to invoke ``send()``.
-        This method relies on mpi4py fast communication optimized for
-        numpy arrays, which discards any information attached to
-        chainer.Variable objects. Please be sure.
-
-        Args:
-            source (int): Target process specifier.
-            tag (int): Message ID (MPI feature).
-
-        """
-
-        chainer.utils.experimental(
-            'chainermn.communicators.CommunicatorBase.recv')
-
-        msgtype = self.mpi_comm.recv(source=source, tag=tag)
-
-        if msgtype.is_tuple:
-            msg = []
-            for shape in msgtype.shapes:
-                buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
-                self.mpi_comm.Recv(buf, source=source, tag=tag)
-                msg.append(buf.reshape(shape))
-            return tuple(msg)
-
-        else:
-            assert len(msgtype.shapes) == 1
-            shape = msgtype.shapes[0]
-            buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
-            self.mpi_comm.Recv(buf, source=source, tag=tag)
-            return buf.reshape(shape)
+        raise NotImplementedError()
 
     def alltoall(self, xs):
-        """A primitive of inter-process all-to-all function.
+        raise NotImplementedError()
 
-        This method tries to invoke all-to-all communication within the
-        communicator. All processes in the communicator are expected to
-        invoke ``alltoall()``. This method relies on mpi4py fast communication
-        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+    # on ndarrays and such
+    def send(self, data, dest, tag):
+        raise NotImplementedError()
 
-        Args:
-            xs (tuple of numpy.ndarray)
+    def recv(self, source, tag):
+        raise NotImplementedError()
 
-        Returns:
-            ys (tuple of numpy.ndarray):
-                Received arrays. The length of tuple equals to
-                the communicator size.
-        """
-        chainer.utils.experimental(
-            'chainermn.communicators.CommunicatorBase.all_to_all')
+    def bcast(self, data, max_buf_len=None, root=0):
+        raise NotImplementedError()
 
-        if len(xs) != self.size:
-            raise ValueError(
-                'The length of data must be same as communicator size.')
+    def gather(self, data, root=0):
+        raise NotImplementedError()
 
-        # Type check.
-        for x in xs:
-            if x.dtype != numpy.float32:
-                raise ValueError(
-                    'alltoall only support dtype == numpy.float32')
+    def allreduce(self, data):
+        raise NotImplementedError()
 
-        # Mediate #axes of arrays.
-        sndims = numpy.array([x.ndim for x in xs], dtype=numpy.int32)
-        rndims = numpy.empty(self.size, dtype=numpy.int32)
-        self.mpi_comm.Alltoall(
-            [sndims, mpi4py.MPI.INT],
-            [rndims, mpi4py.MPI.INT])
+    # on objects
+    def send_obj(self, obj, dest, tag):
+        raise NotImplementedError()
 
-        # Arbitrate shapes of arrays.
-        sshapes = numpy.hstack([x.shape for x in xs]).astype(numpy.int32)
-        rshapes = numpy.empty(sum(rndims), dtype=numpy.int32)
-        self.mpi_comm.Alltoallv(
-            [sshapes, (sndims, _cnt_to_dsp(sndims)), mpi4py.MPI.INT],
-            [rshapes, (rndims, _cnt_to_dsp(rndims)), mpi4py.MPI.INT])
-        shapes = [rshapes[i:i + l]
-                  for i, l in zip(_cnt_to_dsp(rndims), rndims)]
+    def recv_obj(self, source, tag):
+        raise NotImplementedError()
 
-        # Collective communication.
-        slens = [numpy.prod(x.shape) for x in xs]
-        xp = chainer.cuda.get_array_module(xs[0])
-        sbuf = xp.hstack([x.reshape(-1) for x in xs])
-        rlens = [numpy.prod(s) for s in shapes]
-        rbuf = numpy.empty(sum(rlens), dtype=numpy.float32)
-        if xp is not numpy:
-            sbuf = _memory_utility.array_to_buffer_object(sbuf)[0]
-            chainer.cuda.Stream.null.synchronize()
-        self.mpi_comm.Alltoallv(
-            [sbuf, (slens, _cnt_to_dsp(slens)), mpi4py.MPI.FLOAT],
-            [rbuf, (rlens, _cnt_to_dsp(rlens)), mpi4py.MPI.FLOAT])
-        ys = [rbuf[i:i + l].reshape(s)
-              for i, l, s in zip(_cnt_to_dsp(rlens), rlens, shapes)]
+    def bcast_obj(self, data, max_buf_len=None, root=0):
+        raise NotImplementedError()
 
-        return tuple(ys)
+    def gather_obj(self, data, root=0):
+        raise NotImplementedError()
 
-    def bcast(self, x, root=0):
-        """A primitive of inter-process broadcast communication.
+    def allreduce_obj(self, model, op=None):
+        raise NotImplementedError()
 
-        This method tries to invoke broadcast communication within the
-        communicator. All processes in the communicator are expected to
-        invoke ``broadcast()``. This method relies on mpi4py fast communication
-        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+    # Special communication method on grads and data of models
+    def bcast_data(self, model, max_buf_len=None, root=0):
+        '''Broadcast Chainer model data'''
+        raise NotImplementedError()
 
-        Args:
-            x (numpy.array): Array to be broadcasted.
+    def broadcast_data(self, model, max_buf_len=None, root=0):
+        '''Broadcast Chainer model data
 
-        Returns:
-            ys (tuple of numpy.ndarray): Received arrays.
-        """
-        chainer.utils.experimental(
-            'chainermn.communicators.CommunicatorBase.bcast')
+        Left for backward compatibility, but will be removed in future
+        versions. Use bcast_data() method instead.
 
-        is_master = self.mpi_comm.rank == root
-
-        if is_master:
-            msgtype = _MessageType(x)
-            if msgtype.is_tuple:
-                raise TypeError('cannot broadcast tuple data')
-
-            elif x.dtype != numpy.float32:
-                raise ValueError('bcast only support dtype == numpy.float32')
-
-            msgtype = self.mpi_comm.bcast(msgtype, root)
-            shape = msgtype.shapes[0]
-            buf = _memory_utility.array_to_buffer_object(x)
-            self.mpi_comm.Bcast(buf, root)
-            return x
-        else:
-            msgtype = None
-            msgtype = self.mpi_comm.bcast(msgtype, root)
-            shape = msgtype.shapes[0]
-            buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
-            self.mpi_comm.Bcast(buf, root)
-            return buf.reshape(shape)
-
-    def gather(self, x, root=0):
-        """A primitive of inter-process gather communication.
-
-        This method tries to invoke gather communication within the
-        communicator. All processes in the communicator are expected to
-        invoke ``gather()``. This method relies on mpi4py fast communication
-        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
-
-        Note that this method can only handle the same shapes of data
-        over all processes, and cannot handle tuple data.
-
-        Args:
-            x (numpy.array): Array to be gathered.
-
-        Returns:
-            ys (numpy.ndarray):
-                Received arrays with shape (#proc, [data-shape]).
-                ``None`` for non-root processes.
-        """
-        chainer.utils.experimental(
-            'chainermn.communicators.CommunicatorBase.gather')
-
-        is_master = self.mpi_comm.rank == root
-
-        msgtype = _MessageType(x)
-        msgtypes = self.mpi_comm.gather(msgtype, root)
-
-        # Type check.
-        if is_master:
-            shape = msgtype.shapes[0]
-            for msgtype in msgtypes:
-                if msgtype.is_tuple:
-                    raise TypeError('gather cannot handle tuple data')
-
-                assert len(msgtype.shapes) == 1
-
-                if msgtype.shapes[0] != shape:
-                    raise ValueError(
-                        'gather cannot handle different shapes of data')
-
-        if x.dtype != numpy.float32:
-            raise ValueError('gather only support dtype == numpy.float32')
-
-        # Gather data.
-        sbuf = _memory_utility.array_to_buffer_object(x)
-        if is_master:
-            shape = tuple([self.mpi_comm.size]) + shape
-            rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
-        else:
-            rbuf = None
-        self.mpi_comm.Gather(sbuf, rbuf, root)
-
-        if is_master:
-            return rbuf.reshape(shape)
-        else:
-            return None
-
-    def broadcast_data(self, model):
+        '''
         raise NotImplementedError()
 
     def allreduce_grad(self, model):
         raise NotImplementedError()
-
-    def _init_ranks(self):
-        my_ranks = _communication_utility.init_ranks(self.mpi_comm)
-        assert my_ranks[0] == self.mpi_comm.rank
-        self.intra_rank = my_ranks[1]
-        self.intra_size = my_ranks[2]
-        self.inter_rank = my_ranks[3]
-        self.inter_size = my_ranks[4]
-
-    def _init_comms(self):
-        if self.inter_mpi_comm is not None:
-            assert self.intra_mpi_comm is not None
-            assert not self.use_nccl or self.intra_nccl_comm is not None
-            return
-
-        comms = _communication_utility.init_comms(
-            self.mpi_comm, self.intra_rank, self.intra_size, self.inter_rank,
-            use_nccl=self.use_nccl)
-        self.intra_mpi_comm = comms[0]
-        self.inter_mpi_comm = comms[1]
-        if self.use_nccl:
-            self.intra_nccl_comm = comms[2]

--- a/chainermn/communicators/_base.py
+++ b/chainermn/communicators/_base.py
@@ -71,7 +71,7 @@ class CommunicatorBase(object):
         raise NotImplementedError()
 
     # Special communication method on grads and data of models
-    def bcast_data(self, model, max_buf_len=None, root=0):
+    def bcast_data(self, model):
         '''Broadcast Chainer model data'''
         raise NotImplementedError()
 

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -105,8 +105,8 @@ def inter_allreduce_gpu(
 INT_MAX = 2147483647
 
 
-def chunked_bcast(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
-                  root=0):
+def chunked_bcast_obj(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
+                      root=0):
     '''Split object to max_buf_len size chunks and send them out
 
     As mpi4py does not accept an object whose pickled size is larger

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -1,7 +1,7 @@
 import collections
-import mpi4py.MPI
+import pickle
 
-from chainermn.communicators import _memory_utility
+import mpi4py.MPI
 
 
 def init_ranks(mpi_comm):
@@ -75,12 +75,6 @@ def init_comms(mpi_comm, intra_rank, intra_size, inter_rank, use_nccl=True):
         return intra_mpi_comm, inter_mpi_comm
 
 
-def broadcast_naive(mpi_comm, model):
-    for _, param in sorted(model.namedparams()):
-        buf = _memory_utility.array_to_buffer_object(param.data)
-        mpi_comm.Bcast(buf)
-
-
 def inter_allreduce_gpu(
         inter_mpi_comm, size, gpu_buffer_a, gpu_buffer_b,
         n_bytes_buffer, n_elems_per_node, n_bytes_per_node, cuda_stream):
@@ -106,3 +100,73 @@ def inter_allreduce_gpu(
     inter_mpi_comm.Alltoall(
         [gpu_buffer_a.buffer(n_bytes_buffer), mpi4py.MPI.FLOAT],
         [gpu_buffer_b.buffer(n_bytes_buffer), mpi4py.MPI.FLOAT])
+
+
+INT_MAX = 2147483647
+
+
+def chunked_bcast(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
+                  root=0):
+    '''Split object to max_buf_len size chunks and send them out
+
+    As mpi4py does not accept an object whose pickled size is larger
+    than signed integer max (2147483647) the object is pickled and
+    split into chunks.
+
+    Another hack could be try with mpi_comm.bcast(obj) then rank 0
+    node will receive OverflowError from mpi4py. But in that case rank
+    > 0 nodes shall block busy waiting forever at mpi_comm.bcast(obj).
+
+    Args:
+        obj: A Python object that is to be broadcasted.
+        comm: ChainerMN communicator or MPI4py communicator.
+        root (int): The root process of the scatter operation.
+        max_buf_len (int): Max buffer size to be used at broadcasting
+            binaries. Must not be larger than 2147483647 (INT_MAX).
+            Default value is 256MB.
+    Returns:
+        Broadcasted object.
+
+    '''
+    assert max_buf_len < INT_MAX
+    assert max_buf_len > 0
+
+    # check XOR condition of obj is None and rank==0
+    # rank \ obj | None | not None |
+    #   == 0     |  NG  |   OK     |
+    #    > 0     |  OK  |   NG     |
+    assert not (obj is None and mpi_comm.rank == root)
+    assert not (obj is not None and mpi_comm.rank != root)
+
+    if obj is not None and mpi_comm.rank == root:
+        pickled_bytes = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+    else:
+        pickled_bytes = bytearray()
+
+    total_bytes = len(pickled_bytes)
+    total_chunk_num = total_bytes // max_buf_len
+    if (total_bytes % max_buf_len) > 0:
+        total_chunk_num += 1
+
+    data = mpi_comm.bcast((total_chunk_num, max_buf_len, total_bytes))
+    assert data is not None
+    (total_chunk_num, max_buf_len, total_bytes) = data
+
+    for i in range(total_chunk_num):
+        b = i * max_buf_len
+        e = min(b + max_buf_len, total_bytes)
+
+        if mpi_comm.rank == root:
+            buf = pickled_bytes[b:e]
+        else:
+            buf = bytearray(e - b)
+
+        mpi_comm.Bcast(buf, root=root)
+
+        if mpi_comm.rank != root:
+            pickled_bytes[b:e] = buf
+
+    if mpi_comm.rank > root:
+        obj = pickle.loads(pickled_bytes)
+
+    return obj

--- a/chainermn/communicators/dummy_communicator.py
+++ b/chainermn/communicators/dummy_communicator.py
@@ -1,9 +1,8 @@
-from chainermn.communicators import _base
-from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 
 
-class DummyCommunicator(_base.CommunicatorBase):
+class DummyCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     """Dummy communicator that does not communicate at all.
 
@@ -15,9 +14,6 @@ class DummyCommunicator(_base.CommunicatorBase):
         super(DummyCommunicator, self).__init__(mpi_comm, use_nccl=True)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -1,20 +1,16 @@
 import mpi4py.MPI
 
-from chainermn.communicators import _base
-from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 
 
-class FlatCommunicator(_base.CommunicatorBase):
+class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(FlatCommunicator, self).__init__(mpi_comm, False)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/hierarchical_communicator.py
+++ b/chainermn/communicators/hierarchical_communicator.py
@@ -1,21 +1,18 @@
 import chainer.cuda
 import math
 
-from chainermn.communicators import _base
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
 
 
-class HierarchicalCommunicator(_base.CommunicatorBase):
+class HierarchicalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(HierarchicalCommunicator, self).__init__(mpi_comm, use_nccl=True)
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -1,0 +1,379 @@
+import collections
+
+import mpi4py
+import numpy
+
+import chainer.cuda
+import chainer.utils
+from chainermn.communicators import _base
+from chainermn.communicators import _communication_utility
+from chainermn.communicators import _memory_utility
+from chainermn import nccl
+
+
+def _cnt_to_dsp(cnt):
+    """Utility to convert length array to cumulative array."""
+    return [0] + numpy.cumsum(cnt)[:-1].tolist()
+
+
+class _MessageType(object):
+
+    def __init__(self, obj):
+        if isinstance(obj, numpy.ndarray) \
+                or chainer.cuda.get_array_module(obj) is not numpy:
+            self.is_tuple = False
+            self.narr = 1
+            self.ndims = [obj.ndim]
+            self.shapes = [obj.shape]
+        elif isinstance(obj, collections.Iterable):
+            self.is_tuple = True
+            self.narr = len(obj)
+            self.ndims = [x.ndim for x in obj]
+            self.shapes = [x.shape for x in obj]
+        else:
+            raise ValueError(
+                'Message object must be numpy/cupy array or tuple.')
+
+
+class MpiCommunicatorBase(_base.CommunicatorBase):
+    def __init__(self, mpi_comm, use_nccl=False):
+        self.mpi_comm = mpi_comm
+        self._init_ranks()
+
+        if use_nccl and not nccl._available:
+            raise RuntimeError(
+                'NCCL is not available. '
+                'Please confirm that NCCL is enabled in CuPy.'
+            )
+
+        self.use_nccl = use_nccl
+
+        # We have to delay the initialization of communicators. This is because
+        # NCCL's communicators use the current CUDA devices at the time of
+        # initialization. Therefore, we have to initialize NCCL communicators
+        # after users set the devices to use.
+        self.inter_mpi_comm = None
+        self.intra_mpi_comm = None
+        if self.use_nccl:
+            self.intra_nccl_comm = None
+
+    @property
+    def rank(self):
+        return self.mpi_comm.rank
+
+    @property
+    def intra_rank(self):
+        return self._intra_rank
+
+    @property
+    def size(self):
+        return self.mpi_comm.size
+
+    def split(self, color, key):
+        """A wrapper function of MPI_Comm_Split.
+
+        This method splits the inter MPI commnicator and return a wrapped
+        ChainerMN communicator.
+
+        Args:
+            color (int):
+                Index of new group. The process with the same color will be
+                assigned to the same group.
+            key (int):
+                Control of rank assignment. The process will be assigned
+                a rank in the new group ordered by the value of key.
+                If you do not care of the rank, you can just simply specify
+                the original rank.
+
+        Returns:
+            CommunicatorBase
+        """
+        return self.__class__(mpi_comm=self.mpi_comm.Split(color, key))
+
+    def alltoall(self, xs):
+        """A primitive of inter-process all-to-all function.
+
+        This method tries to invoke all-to-all communication within the
+        communicator. All processes in the communicator are expected to
+        invoke ``alltoall()``. This method relies on mpi4py fast communication
+        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        Args:
+            xs (tuple of numpy.ndarray)
+
+        Returns:
+            ys (tuple of numpy.ndarray):
+                Received arrays. The length of tuple equals to
+                the communicator size.
+        """
+        chainer.utils.experimental(
+            'chainermn.communicators.CommunicatorBase.all_to_all')
+
+        if len(xs) != self.size:
+            raise ValueError(
+                'The length of data must be same as communicator size.')
+
+        # Type check.
+        for x in xs:
+            if x.dtype != numpy.float32:
+                raise ValueError(
+                    'alltoall only support dtype == numpy.float32')
+
+        # Mediate #axes of arrays.
+        sndims = numpy.array([x.ndim for x in xs], dtype=numpy.int32)
+        rndims = numpy.empty(self.size, dtype=numpy.int32)
+        self.mpi_comm.Alltoall(
+            [sndims, mpi4py.MPI.INT],
+            [rndims, mpi4py.MPI.INT])
+
+        # Arbitrate shapes of arrays.
+        sshapes = numpy.hstack([x.shape for x in xs]).astype(numpy.int32)
+        rshapes = numpy.empty(sum(rndims), dtype=numpy.int32)
+        self.mpi_comm.Alltoallv(
+            [sshapes, (sndims, _cnt_to_dsp(sndims)), mpi4py.MPI.INT],
+            [rshapes, (rndims, _cnt_to_dsp(rndims)), mpi4py.MPI.INT])
+        shapes = [rshapes[i:i + l]
+                  for i, l in zip(_cnt_to_dsp(rndims), rndims)]
+
+        # Collective communication.
+        slens = [numpy.prod(x.shape) for x in xs]
+        xp = chainer.cuda.get_array_module(xs[0])
+        sbuf = xp.hstack([x.reshape(-1) for x in xs])
+        rlens = [numpy.prod(s) for s in shapes]
+        rbuf = numpy.empty(sum(rlens), dtype=numpy.float32)
+        if xp is not numpy:
+            sbuf = _memory_utility.array_to_buffer_object(sbuf)[0]
+            chainer.cuda.Stream.null.synchronize()
+        self.mpi_comm.Alltoallv(
+            [sbuf, (slens, _cnt_to_dsp(slens)), mpi4py.MPI.FLOAT],
+            [rbuf, (rlens, _cnt_to_dsp(rlens)), mpi4py.MPI.FLOAT])
+        ys = [rbuf[i:i + l].reshape(s)
+              for i, l, s in zip(_cnt_to_dsp(rlens), rlens, shapes)]
+
+        return tuple(ys)
+
+    def send(self, data, dest, tag):
+        """A primitive for inter-process transmitter.
+
+        This method sends numpy-array to target process.
+        The target process is expected to invoke ``recv()``.
+        This method relies on mpi4py fast communication optimized for
+        numpy arrays, which discards any information attached to
+        chainer.Variable objects. Please be sure.
+
+        Args:
+            data: data to be sent (tuple, list or raw numpy/cupy array)
+            dest (int): Target process specifier.
+            tag (int): Message ID (MPI feature).
+
+        """
+        chainer.utils.experimental(
+            'chainermn.communicators.CommunicatorBase.send')
+
+        msgtype = _MessageType(data)
+        """We use ssend() instead of send() to pass unittests.
+        If we don't use it, an error occurs in
+        test_point_to_point_communication.py
+        when using MVAPICH2-2.2 and GPUs.
+        """
+        self.mpi_comm.ssend(msgtype, dest=dest, tag=tag)
+
+        # Type check.
+        if not msgtype.is_tuple:
+            data = [data]
+
+        for x in data:
+            if x.dtype != numpy.float32:
+                raise ValueError('send only support dtype == numpy.float32')
+
+        for array in data:
+            if chainer.cuda.get_array_module(array) is not numpy:
+                chainer.cuda.Stream.null.synchronize()
+
+            buf = _memory_utility.array_to_buffer_object(array)
+            """We use Ssend() for the same reason as using ssend()."""
+            self.mpi_comm.Ssend(buf, dest=dest, tag=tag)
+
+    def recv(self, source, tag):
+        """A primitive of inter-process receiver.
+
+        This method tries to receive numpy-array from target process.
+        The target process is expected to invoke ``send()``.
+        This method relies on mpi4py fast communication optimized for
+        numpy arrays, which discards any information attached to
+        chainer.Variable objects. Please be sure.
+
+        Args:
+            source (int): Target process specifier.
+            tag (int): Message ID (MPI feature).
+
+        """
+
+        chainer.utils.experimental(
+            'chainermn.communicators.CommunicatorBase.recv')
+
+        msgtype = self.mpi_comm.recv(source=source, tag=tag)
+
+        if msgtype.is_tuple:
+            msg = []
+            for shape in msgtype.shapes:
+                buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+                self.mpi_comm.Recv(buf, source=source, tag=tag)
+                msg.append(buf.reshape(shape))
+            return tuple(msg)
+
+        else:
+            assert len(msgtype.shapes) == 1
+            shape = msgtype.shapes[0]
+            buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+            self.mpi_comm.Recv(buf, source=source, tag=tag)
+            return buf.reshape(shape)
+
+    def bcast(self, x, root=0):
+        """A primitive of inter-process broadcast communication.
+
+        This method tries to invoke broadcast communication within the
+        communicator. All processes in the communicator are expected to
+        invoke ``broadcast()``. This method relies on mpi4py fast communication
+        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        Args:
+            x (numpy.array): Array to be broadcasted.
+
+        Returns:
+            ys (tuple of numpy.ndarray): Received arrays.
+        """
+        chainer.utils.experimental(
+            'chainermn.communicators.MpiCommunicatorBase.bcast')
+
+        is_master = self.mpi_comm.rank == root
+
+        if is_master:
+            msgtype = _MessageType(x)
+            if msgtype.is_tuple:
+                raise TypeError('Tuple data cannot be broadcasted')
+
+            elif x.dtype != numpy.float32:
+                raise ValueError(
+                    'MPI broadcast only supports dtype == numpy.float32')
+
+            msgtype = self.mpi_comm.bcast(msgtype, root)
+            shape = msgtype.shapes[0]
+            buf = _memory_utility.array_to_buffer_object(x)
+            self.mpi_comm.Bcast(buf, root)
+            return x
+        else:
+            msgtype = None
+            msgtype = self.mpi_comm.bcast(msgtype, root)
+            shape = msgtype.shapes[0]
+            buf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+            self.mpi_comm.Bcast(buf, root)
+            return buf.reshape(shape)
+
+    def gather(self, x, root=0):
+        """A primitive of inter-process gather communication.
+
+        This method tries to invoke gather communication within the
+        communicator. All processes in the communicator are expected to
+        invoke ``gather()``. This method relies on mpi4py fast communication
+        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        Note that this method can only handle the same shapes of data
+        over all processes, and cannot handle tuple data.
+
+        Args:
+            x (numpy.array): Array to be gathered.
+
+        Returns:
+            ys (numpy.ndarray):
+                Received arrays with shape (#proc, [data-shape]).
+                ``None`` for non-root processes.
+        """
+        chainer.utils.experimental(
+            'chainermn.communicators.CommunicatorBase.gather')
+
+        is_master = self.mpi_comm.rank == root
+
+        msgtype = _MessageType(x)
+        msgtypes = self.mpi_comm.gather(msgtype, root)
+
+        # Type check.
+        if is_master:
+            shape = msgtype.shapes[0]
+            for msgtype in msgtypes:
+                if msgtype.is_tuple:
+                    raise TypeError('gather cannot handle tuple data')
+
+                assert len(msgtype.shapes) == 1
+
+                if msgtype.shapes[0] != shape:
+                    raise ValueError(
+                        'gather cannot handle different shapes of data')
+
+        if x.dtype != numpy.float32:
+            raise ValueError('gather only support dtype == numpy.float32')
+
+        # Gather data.
+        sbuf = _memory_utility.array_to_buffer_object(x)
+        if is_master:
+            shape = tuple([self.mpi_comm.size]) + shape
+            rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+        else:
+            rbuf = None
+        self.mpi_comm.Gather(sbuf, rbuf, root)
+
+        if is_master:
+            return rbuf.reshape(shape)
+        else:
+            return None
+
+    # Objects
+    def send_obj(self, obj, dest):
+        self.mpi_comm.send(obj, dest=dest)
+
+    def recv_obj(self, source):
+        return self.mpi_comm.recv(source=source)
+
+    def bcast_obj(self, obj, max_buf_len=None, root=0):
+        if max_buf_len is None:
+            max_buf_len = 256 * 1024 * 1024
+        return _communication_utility.chunked_bcast(obj,
+                                                    self.mpi_comm,
+                                                    max_buf_len=max_buf_len,
+                                                    root=root)
+
+    def gather_obj(self, obj, root=0):
+        return self.mpi_comm.gather(obj, root=root)
+
+    def allreduce_obj(self, obj, op=None):
+        # Summation by default
+        return self.mpi_comm.allreduce(obj)
+
+    def bcast_data(self, model):
+        for _, param in sorted(model.namedparams()):
+            buf = _memory_utility.array_to_buffer_object(param.data)
+            self.mpi_comm.Bcast(buf)
+
+    broadcast_data = bcast_data
+
+    def _init_ranks(self):
+        my_ranks = _communication_utility.init_ranks(self.mpi_comm)
+        assert my_ranks[0] == self.mpi_comm.rank
+        self._intra_rank = my_ranks[1]
+        self.intra_size = my_ranks[2]
+        self.inter_rank = my_ranks[3]
+        self.inter_size = my_ranks[4]
+
+    def _init_comms(self):
+        if self.inter_mpi_comm is not None:
+            assert self.intra_mpi_comm is not None
+            assert not self.use_nccl or self.intra_nccl_comm is not None
+            return
+
+        comms = _communication_utility.init_comms(
+            self.mpi_comm, self.intra_rank, self.intra_size, self.inter_rank,
+            use_nccl=self.use_nccl)
+        self.intra_mpi_comm = comms[0]
+        self.inter_mpi_comm = comms[1]
+        if self.use_nccl:
+            self.intra_nccl_comm = comms[2]

--- a/chainermn/communicators/naive_communicator.py
+++ b/chainermn/communicators/naive_communicator.py
@@ -1,17 +1,13 @@
 import mpi4py.MPI
 
-from chainermn.communicators import _base
-from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 
 
-class NaiveCommunicator(_base.CommunicatorBase):
+class NaiveCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(NaiveCommunicator, self).__init__(mpi_comm)
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         for param in _memory_utility.extract_params(model):

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -2,12 +2,12 @@ import chainer.cuda
 import math
 import mpi4py.MPI
 
-from chainermn.communicators import _base
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
 
 
-class NonCudaAwareCommunicator(_base.CommunicatorBase):
+class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(NonCudaAwareCommunicator, self).__init__(mpi_comm, use_nccl=True)
@@ -16,13 +16,15 @@ class NonCudaAwareCommunicator(_base.CommunicatorBase):
         self.cpu_buffer_a = _memory_utility.HostPinnedMemory()
         self.cpu_buffer_b = _memory_utility.HostPinnedMemory()
 
-    def broadcast_data(self, model):
+    def bcast_data(self, model):
         for _, param in sorted(model.namedparams()):
             data = param.data
             tmp_cpu = chainer.cuda.to_cpu(data)
             self.mpi_comm.Bcast(tmp_cpu)
             tmp_gpu = chainer.cuda.to_gpu(tmp_cpu)
             data[:] = tmp_gpu
+
+    broadcast_data = bcast_data
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -24,8 +24,6 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             tmp_gpu = chainer.cuda.to_gpu(tmp_cpu)
             data[:] = tmp_gpu
 
-    broadcast_data = bcast_data
-
     def allreduce_grad(self, model):
         self._init_comms()
         stream = chainer.cuda.Stream.null

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -1,14 +1,14 @@
 import chainer.cuda
 
-from chainermn.communicators import _base
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
 
 import numpy as np
 
 
-class PureNcclCommunicator(_base.CommunicatorBase):
+class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm, allreduce_grad_dtype=None):
         super(PureNcclCommunicator, self).__init__(mpi_comm, True)
@@ -61,9 +61,6 @@ class PureNcclCommunicator(_base.CommunicatorBase):
         self.inter_mpi_comm = comms[1]
         self.intra_nccl_comm = comms[2]
         self.nccl_comm = comms[3]
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         stream = chainer.cuda.Stream.null

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -42,7 +42,7 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
     def _init_ranks(self):
         my_ranks = _communication_utility.init_ranks(self.mpi_comm)
         assert my_ranks[0] == self.mpi_comm.rank
-        self.intra_rank = my_ranks[1]
+        self._intra_rank = my_ranks[1]
         self.intra_size = my_ranks[2]
         self.inter_rank = my_ranks[3]
         self.inter_size = my_ranks[4]

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -1,11 +1,11 @@
 import chainer.cuda
 
-from chainermn.communicators import _base
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
 
 
-class SingleNodeCommunicator(_base.CommunicatorBase):
+class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
         super(SingleNodeCommunicator, self).__init__(mpi_comm, use_nccl=True)
@@ -17,7 +17,7 @@ class SingleNodeCommunicator(_base.CommunicatorBase):
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
 
-    def broadcast_data(self, model):
+    def bcast_data(self, model):
         self._init_comms()
         stream = chainer.cuda.Stream.null
 
@@ -36,6 +36,8 @@ class SingleNodeCommunicator(_base.CommunicatorBase):
 
         _memory_utility.unpack_params(
             params, itemsize, 'data', self.gpu_buffer_a)
+
+    broadcast_data = bcast_data
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -37,8 +37,6 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         _memory_utility.unpack_params(
             params, itemsize, 'data', self.gpu_buffer_a)
 
-    broadcast_data = bcast_data
-
     def allreduce_grad(self, model):
         self._init_comms()
         stream = chainer.cuda.Stream.null

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -2,22 +2,19 @@ import chainer.cuda
 import math
 import mpi4py.MPI
 
-from chainermn.communicators import _base
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
+from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
 
 
-class TwoDimensionalCommunicator(_base.CommunicatorBase):
+class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm=mpi4py.MPI.COMM_WORLD):
         super(TwoDimensionalCommunicator, self).__init__(
             mpi_comm, use_nccl=True)
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
-
-    def broadcast_data(self, model):
-        _communication_utility.broadcast_naive(self.mpi_comm, model)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/datasets/scatter_dataset.py
+++ b/chainermn/datasets/scatter_dataset.py
@@ -64,7 +64,6 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
             if i == root:
                 mine = chainer.datasets.SubDataset(dataset, b, e, order)
             else:
-                print((b, e))
                 comm.send_obj((b, e), dest=i)
         assert mine is not None
         return mine

--- a/chainermn/datasets/scatter_dataset.py
+++ b/chainermn/datasets/scatter_dataset.py
@@ -1,4 +1,3 @@
-import pickle
 import warnings
 
 import chainer.datasets
@@ -7,75 +6,6 @@ import numpy
 
 class DataSizeError(RuntimeError):
     pass
-
-
-INT_MAX = 2147483647
-
-
-def chunked_bcast(obj, comm,
-                  max_buf_len=256 * 1024 * 1024,  # 256MB default
-                  root=0):
-    '''Split object to max_buf_len size chunks and send them out
-
-    As mpi4py does not accept an object whose pickled size is larger
-    than signed integer max (2147483647) the object is pickled and
-    split into chunks.
-
-    Another hack could be try with comm.bcast(obj) then rank 0 node
-    will receive OverflowError from mpi4py. But in that case rank > 0
-    nodes shall block busy waiting forever at comm.bcast(obj).
-
-    Args:
-        obj: A Python object that is to be broadcasted.
-        comm: ChainerMN communicator or MPI4py communicator.
-        root (int): The root process of the scatter operation.
-        max_buf_len (int): Max buffer size to be used at broadcasting
-            binaries. Must not be larger than 2147483647.
-    Returns:
-        Broadcasted object.
-    '''
-    assert max_buf_len < INT_MAX
-    assert max_buf_len > 0
-
-    # check XOR condition of obj is None and rank==0
-    # rank \ obj | None | not None |
-    #   == 0     |  NG  |   OK     |
-    #    > 0     |  OK  |   NG     |
-    assert not (obj is None and comm.rank == root)
-    assert not (obj is not None and comm.rank != root)
-
-    if obj is not None and comm.rank == root:
-        pickled_bytes = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
-    else:
-        pickled_bytes = bytearray()
-
-    total_bytes = len(pickled_bytes)
-    total_chunk_num = total_bytes // max_buf_len
-    if (total_bytes % max_buf_len) > 0:
-        total_chunk_num += 1
-
-    data = comm.bcast((total_chunk_num, max_buf_len, total_bytes))
-    assert data is not None
-    (total_chunk_num, max_buf_len, total_bytes) = data
-
-    for i in range(total_chunk_num):
-        b = i * max_buf_len
-        e = min(b + max_buf_len, total_bytes)
-
-        if comm.rank == root:
-            buf = pickled_bytes[b:e]
-        else:
-            buf = bytearray(e - b)
-
-        comm.Bcast(buf, root=root)
-
-        if comm.rank != root:
-            pickled_bytes[b:e] = buf
-
-    if comm.rank > root:
-        obj = pickle.loads(pickled_bytes)
-
-    return obj
 
 
 def scatter_dataset(dataset, comm, root=0, shuffle=False,
@@ -106,10 +36,6 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
         Scattered dataset.
     """
 
-    if hasattr(comm, 'mpi_comm'):
-        comm = comm.mpi_comm
-    assert hasattr(comm, 'send')
-    assert hasattr(comm, 'recv')
     assert 0 <= root and root < comm.size
 
     order = None
@@ -122,7 +48,7 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
     if comm.rank == 0:
         data = (dataset, order)
 
-    data = chunked_bcast(data, comm, max_buf_len=max_buf_len)
+    data = comm.bcast_obj(data, max_buf_len=max_buf_len, root=0)
     assert data is not None
     (dataset, order) = data
 
@@ -138,12 +64,13 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
             if i == root:
                 mine = chainer.datasets.SubDataset(dataset, b, e, order)
             else:
-                comm.send((b, e), dest=i)
+                print((b, e))
+                comm.send_obj((b, e), dest=i)
         assert mine is not None
         return mine
 
     else:
-        data = comm.recv(source=root)
+        data = comm.recv_obj(source=root)
         assert data is not None
         (b, e) = data
         return chainer.datasets.SubDataset(dataset, b, e, order)
@@ -169,15 +96,11 @@ def get_n_iterations_for_one_epoch(dataset, local_batch_size, comm):
         'get_n_iterations_for_one_epoch is deprecated. Please use '
         'standard epoch triggers.', DeprecationWarning)
 
-    if hasattr(comm, 'mpi_comm'):
-        comm = comm.mpi_comm
-    assert hasattr(comm, 'bcast')
-
     n_iterations = None
     if comm.rank == 0:
         n_iterations = (len(dataset) + local_batch_size -
                         1) // local_batch_size
-    return comm.bcast(n_iterations)
+    return comm.bcast_obj(n_iterations)
 
 
 def get_epoch_trigger(n_epochs, dataset, local_batch_size, comm):

--- a/chainermn/extensions/allreduce_persistent.py
+++ b/chainermn/extensions/allreduce_persistent.py
@@ -39,6 +39,11 @@ class AllreducePersistent(chainer.training.extension.Extension):
     def __init__(self, model, comm):
         if hasattr(comm, 'mpi_comm'):
             comm = comm.mpi_comm
+        else:
+            # TODO(kuenishi): wrap this speciall allreduce with
+            # CommunicatorBase interface
+            raise ValueError(
+                'allreduce_persistent is only in MPI-based communicator.')
 
         self.model = model
         self.comm = comm

--- a/chainermn/extensions/checkpoint.py
+++ b/chainermn/extensions/checkpoint.py
@@ -154,7 +154,7 @@ class _MultiNodeCheckpointer(extension.Extension):
         self.files.append(filename)
 
         if len(self.files) - self.cp_interval > 5:
-            # remove older snapshots, and bcast latest list
+            # remove older snapshots, and broadcast latest list
             self._sync_file_list(remove_remainder=True)
 
     def finalize(self):
@@ -188,7 +188,7 @@ class _MultiNodeCheckpointer(extension.Extension):
         return self.stats.report()
 
     def _sync_file_list(self, remove_remainder=False):
-        file_lists = self.comm.mpi_comm.gather(self.files, root=0)
+        file_lists = self.comm.gather_obj(self.files)
 
         iters0 = None
         if self.comm.rank == 0:
@@ -211,7 +211,7 @@ class _MultiNodeCheckpointer(extension.Extension):
             else:
                 raise RuntimeError("Can't gather checkpoint file names")
 
-        iters0 = self.comm.mpi_comm.bcast(iters0, root=0)
+        iters0 = self.comm.bcast_obj(iters0)
         files = self._filenames(iters0)
 
         if remove_remainder:

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -28,7 +28,7 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
         local_mean_dict = self._mn_original_evaluate()
         global_mean_dict = {
             name:
-            self._mn_communicator.mpi_comm.allreduce(
+            self._mn_communicator.allreduce_obj(
                 value) / self._mn_communicator.size
             for name, value in sorted(local_mean_dict.items())
         }

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -114,6 +114,9 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             axis = (0,) + tuple(range(head_ndim, x.ndim))
 
             # ChainerMN diff (1/2) begins
+            # This was intentionally left as MPI's allreduce because
+            # MPI was optimized for small messages, while earlier
+            # NCCL2 was optmized for larger messages.
             mpi_comm = self.comm.mpi_comm
             tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
             x.mean(axis=axis, out=tmp[:gamma.size])

--- a/chainermn/iterators/multi_node_iterator.py
+++ b/chainermn/iterators/multi_node_iterator.py
@@ -55,7 +55,7 @@ class _MultiNodeIterator_Master(object):
     def serialize(self, serializer):
         # Master's and Slave's serialize must be called at the same time.
         self.actual_iterator.serialize(serializer)
-        self.communicator.mpi_comm.bcast(
+        self.communicator.bcast_obj(
             serializer, root=self.rank_master)
 
 
@@ -99,7 +99,7 @@ class _MultiNodeIterator_Slave(chainer.dataset.iterator.Iterator):
 
     def serialize(self, serializer):
         # Master's and Slave's serialize must be called at the same time.
-        _serializer = self.communicator.mpi_comm.bcast(
+        _serializer = self.communicator.bcast_obj(
             None, root=self.rank_master)
 
         self.current_position = serializer(

--- a/chainermn/optimizers.py
+++ b/chainermn/optimizers.py
@@ -25,7 +25,7 @@ class _MultiNodeOptimizer(object):
             del loss
 
         if self.is_changed(target):
-            self.communicator.broadcast_data(target)
+            self.communicator.bcast_data(target)
         else:
             self.communicator.allreduce_grad(target)
             self.actual_optimizer.update(None, *args, **kwds)
@@ -80,7 +80,7 @@ class _DoubleBufferingOptimizer(object):
 
         if self.is_changed(target, self.target_params_list[0]):
             self.wait()
-            self.communicator.broadcast_data(target)
+            self.communicator.bcast_data(target)
             super(_DoubleBufferingOptimizer, self).__setattr__(
                 'communicated_target', copy.deepcopy(target))
             super(_DoubleBufferingOptimizer, self).__setattr__(

--- a/examples/dcgan/train_dcgan.py
+++ b/examples/dcgan/train_dcgan.py
@@ -7,7 +7,6 @@ import os
 import chainer
 from chainer import training
 from chainer.training import extensions
-from mpi4py import MPI
 
 from net import Discriminator
 from net import Generator
@@ -60,9 +59,9 @@ def main():
         comm = chainermn.create_communicator('naive')
         device = -1
 
-    if comm.mpi_comm.rank == 0:
+    if comm.rank == 0:
         print('==========================================')
-        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Num process (COMM_WORLD): {}'.format(comm.size))
         if args.gpu:
             print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -135,7 +135,7 @@ def main():
     comm = chainermn.create_communicator(args.communicator)
     device = comm.intra_rank
 
-    if comm.mpi_comm.rank == 0:
+    if comm.rank == 0:
         print('==========================================')
         print('Num process (COMM_WORLD): {}'.format(comm.size))
         print('Using {} communicator'.format(args.communicator))

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
-from mpi4py import MPI
 
 import chainermn
 
@@ -62,9 +61,9 @@ def main():
         comm = chainermn.create_communicator('naive')
         device = -1
 
-    if comm.mpi_comm.rank == 0:
+    if comm.rank == 0:
         print('==========================================')
-        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Num process (COMM_WORLD): {}'.format(comm.size))
         if args.gpu:
             print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))

--- a/examples/mnist/train_mnist_checkpoint.py
+++ b/examples/mnist/train_mnist_checkpoint.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
-from mpi4py import MPI
 
 import chainermn
 from chainermn.extensions import create_multi_node_checkpointer
@@ -65,9 +64,9 @@ ChainerMN example: MNIST with automatic checkpoints enabled''')
         comm = chainermn.create_communicator('naive')
         device = -1
 
-    if comm.mpi_comm.rank == 0:
+    if comm.rank == 0:
         print('==========================================')
-        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Num process (COMM_WORLD): {}'.format(comm.size))
         if args.gpu:
             print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -8,7 +8,6 @@ import re
 import sys
 import time
 
-from mpi4py import MPI
 from nltk.translate import bleu_score
 import numpy
 import six
@@ -226,7 +225,7 @@ class BleuEvaluator(extensions.Evaluator):
 
         if self.comm is not None:
             # This evaluator is called via chainermn.MultiNodeEvaluator
-            for i in range(0, self.comm.mpi_comm.size):
+            for i in range(0, self.comm.size):
                 print("BleuEvaluator::evaluate(): "
                       "took {:.3f} [s]".format(et - bt))
                 sys.stdout.flush()
@@ -342,9 +341,9 @@ def main():
         comm = chainermn.create_communicator('naive')
         dev = -1
 
-    if comm.mpi_comm.rank == 0:
+    if comm.rank == 0:
         print('==========================================')
-        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Num process (COMM_WORLD): {}'.format(comm.size))
         if args.gpu:
             print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))
@@ -415,8 +414,8 @@ def main():
         comm.mpi_comm.Barrier()
 
     # broadcast id- > word dictionary
-    source_ids = comm.mpi_comm.bcast(source_ids, root=0)
-    target_ids = comm.mpi_comm.bcast(target_ids, root=0)
+    source_ids = comm.bcast_obj(source_ids, root=0)
+    target_ids = comm.bcast_obj(target_ids, root=0)
 
     target_words = {i: w for w, i in target_ids.items()}
     source_words = {i: w for w, i in source_ids.items()}

--- a/examples/seq2seq/seq2seq_mp1.py
+++ b/examples/seq2seq/seq2seq_mp1.py
@@ -8,7 +8,6 @@ import re
 import sys
 import time
 
-from mpi4py import MPI
 from nltk.translate import bleu_score
 import numpy
 import six
@@ -367,7 +366,7 @@ def main():
 
     if comm.rank == 0:
         print('==========================================')
-        print('Num process (COMM_WORLD): {}'.format(MPI.COMM_WORLD.Get_size()))
+        print('Num process (COMM_WORLD): {}'.format(comm.size))
         if args.gpu:
             print('Using GPUs')
         print('Using {} communicator'.format(args.communicator))
@@ -437,8 +436,8 @@ def main():
         comm.mpi_comm.Barrier()
 
     # broadcast id -> word dictionary
-    source_ids = comm.mpi_comm.bcast(source_ids, root=0)
-    target_ids = comm.mpi_comm.bcast(target_ids, root=0)
+    source_ids = comm.bcast_obj(source_ids, root=0)
+    target_ids = comm.bcast_obj(target_ids, root=0)
 
     target_words = {i: w for w, i in target_ids.items()}
     source_words = {i: w for w, i in source_ids.items()}

--- a/tests/chainermn_tests/communicator_tests/test_communication_utility.py
+++ b/tests/chainermn_tests/communicator_tests/test_communication_utility.py
@@ -1,0 +1,36 @@
+import mpi4py
+import numpy as np
+import pytest
+import unittest
+
+from chainermn.communicators._communication_utility import chunked_bcast  # NOQA
+from chainermn.communicators._communication_utility import INT_MAX  # NOQA
+from chainermn.communicators.naive_communicator import NaiveCommunicator
+
+
+class TestCommunicationUtility(unittest.TestCase):
+    def setUp(self):
+        self.mpi_comm = mpi4py.MPI.COMM_WORLD
+        self.communicator = NaiveCommunicator(self.mpi_comm)
+
+    def test_chunked_bcasts(self):
+        # success
+        for (s, l) in [(10, 1), (1024, 7), (355678, 2378), (234, INT_MAX - 1)]:
+            self.check_chunked_bcast(s, l)
+        # fail
+        for (s, l) in [(200, -1), (23, INT_MAX)]:
+            with pytest.raises(AssertionError):
+                self.check_chunked_bcast(s, l)
+
+    def check_chunked_bcast(self, data_size, max_buf_len):
+        root = 0
+        obj = np.arange(data_size)
+        src = None
+        if self.communicator.rank == root:
+            src = obj
+
+        dst = chunked_bcast(src, self.communicator.mpi_comm,
+                            max_buf_len, root)
+        assert len(dst) == len(obj)
+        for i in range(len(obj)):
+            assert dst[i] == obj[i]

--- a/tests/chainermn_tests/communicator_tests/test_communication_utility.py
+++ b/tests/chainermn_tests/communicator_tests/test_communication_utility.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import unittest
 
-from chainermn.communicators._communication_utility import chunked_bcast  # NOQA
+from chainermn.communicators._communication_utility import chunked_bcast_obj  # NOQA
 from chainermn.communicators._communication_utility import INT_MAX  # NOQA
 from chainermn.communicators.naive_communicator import NaiveCommunicator
 
@@ -13,24 +13,24 @@ class TestCommunicationUtility(unittest.TestCase):
         self.mpi_comm = mpi4py.MPI.COMM_WORLD
         self.communicator = NaiveCommunicator(self.mpi_comm)
 
-    def test_chunked_bcasts(self):
+    def test_chunked_bcast_objs(self):
         # success
         for (s, l) in [(10, 1), (1024, 7), (355678, 2378), (234, INT_MAX - 1)]:
-            self.check_chunked_bcast(s, l)
+            self.check_chunked_bcast_obj(s, l)
         # fail
         for (s, l) in [(200, -1), (23, INT_MAX)]:
             with pytest.raises(AssertionError):
-                self.check_chunked_bcast(s, l)
+                self.check_chunked_bcast_obj(s, l)
 
-    def check_chunked_bcast(self, data_size, max_buf_len):
+    def check_chunked_bcast_obj(self, data_size, max_buf_len):
         root = 0
         obj = np.arange(data_size)
         src = None
         if self.communicator.rank == root:
             src = obj
 
-        dst = chunked_bcast(src, self.communicator.mpi_comm,
-                            max_buf_len, root)
+        dst = chunked_bcast_obj(src, self.communicator.mpi_comm,
+                                max_buf_len, root)
         assert len(dst) == len(obj)
         for i in range(len(obj)):
             assert dst[i] == obj[i]

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -154,11 +154,11 @@ def check_send_and_recv_tuple(communicator, data):
         communicator.send(data, dest=rank_next, tag=0)
 
 
-def check_broadcast_data(communicator, model):
+def check_bcast_data(communicator, model):
     model.a.W.data[:] = communicator.rank
     model.b.W.data[:] = communicator.rank + 1
     model.c.b.data[:] = communicator.rank + 2
-    communicator.broadcast_data(model)
+    communicator.bcast_data(model)
     chainer.testing.assert_allclose(model.a.W.data, 0 * np.ones((3, 2)))
     chainer.testing.assert_allclose(model.b.W.data, 1 * np.ones((4, 3)))
     chainer.testing.assert_allclose(model.c.b.data, 2 * np.ones((5, )))
@@ -228,7 +228,7 @@ def check_collective_communication(param, use_gpu):
     model = ExampleModel(param.model_dtype)
     if use_gpu:
         model.to_gpu()
-    check_broadcast_data(communicator, model)
+    check_bcast_data(communicator, model)
     check_allreduce_grad(communicator, model)
     check_allreduce_grad_empty(communicator, model)
 

--- a/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
+++ b/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
@@ -5,14 +5,14 @@ import unittest
 import mpi4py.MPI
 import pytest
 
-from chainermn.communicators import _base
+from chainermn.communicators import mpi_communicator_base
 
 
-class TestCommunicatorBase(unittest.TestCase):
+class TestMpiCommunicatorBase(unittest.TestCase):
 
     def setUp(self):
         self.mpi_comm = mpi4py.MPI.COMM_WORLD
-        self.communicator = _base.CommunicatorBase(
+        self.communicator = mpi_communicator_base.MpiCommunicatorBase(
             self.mpi_comm, use_nccl=False)
 
     def test_intra_rank_with_env(self):


### PR DESCRIPTION
This patch introduces naming rule to communicator API methods, as
adding suffix `_obj` for Python object transfers. Also changes
`broadcast_data` to `bcast_data` to unify broadcasting names to bcast,
which had possibility to confuse users with `broadcast_to` in
chainer.functions. Also it hides mpi_comm usage (except `Barrier()`
usage). This patch also introduce MpiCommunicatorBase to make
CommunicatorBase purely "virtual" interface class that has no
implementation, but just interface.
