### PR TITLE
Fix a bug of NStepRNN

### DIFF
--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -23,7 +23,7 @@ class _MultiNodeNStepRNN(chainer.Chain):
     def __init__(self, link, communicator, rank_in, rank_out):
         if chainer.__version__.startswith('4.0.0b'):
             raise ValueError(
-                'Multi node stacked RNN link is not support '
+                'Multi node stacked RNN link does not support '
                 'Chainer 4.0.0b1-4.0.0b4 versions.')
 
         super(_MultiNodeNStepRNN, self).__init__(actual_rnn=link)

--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -4,8 +4,18 @@ import chainer.links.connection as lconn
 import chainermn.functions
 
 
-# Chainer <=v3
-CHAINER_VERSION_OLD_RNN = (int(chainer.__version__.split('.')[0]) <= 3)
+def _is_old_rnn():
+    major_version = int(chainer.__version__.split('.')[0])
+    if major_version <= 3:
+        return True
+    elif chainer.__version__.startswith('4.0.0b'):
+        return True
+    else:
+        return False
+
+
+CHAINER_VERSION_OLD_RNN = _is_old_rnn()
+
 
 if CHAINER_VERSION_OLD_RNN:
     _rnn_n_cells = {

--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -38,13 +38,16 @@ class _MultiNodeNStepRNN(chainer.Chain):
         self.rank_out = rank_out
 
         if CHAINER_VERSION_OLD_RNN:
+            print('hasattr(link, rnn)', hasattr(link, 'rnn'))
+            print(' link.rnn',  link.rnn)
+            print('link.rnn not in _rnn_n_cells', link.rnn not in _rnn_n_cells)
             if not hasattr(link, 'rnn') or link.rnn not in _rnn_n_cells:
                 raise ValueError(
                     'link must be NStepRNN and its inherited link')
             else:
                 self.n_cells = _rnn_n_cells[link.rnn]
 
-        else:  # expect Chainer >4.0.0b3
+        else:  # expect Chainer >=4.0.0rc1
             check_lstm = isinstance(link, lconn.n_step_rnn.NStepRNNBase)
             if not check_lstm:
                 raise ValueError(


### PR DESCRIPTION
I fixed a bug of NStepRNN. 
An error occurs in current  MultiNodeNStepRNN when Chainer v4.0.0b1-v4.0.0b4.
After an offline discussion, ChainerMN will not support Chainer v4.0.0b1-v4.0.0b4, because they are beta version.
So, I changed to raise the exception in MultiNodeNStepRNN  when Chainer v4.0.0b1-v4.0.0b4 were used.