### PR TITLE
Update supported Chainer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ python:
 
 env:
   - MPI="mpich-3.0.4"    CHAINER_VER="3.5.0"
-  - MPI="mpich-3.0.4"    CHAINER_VER="4.0.0rc1"
+  - MPI="mpich-3.0.4"    CHAINER_VER="4.0.0"
   - MPI="mpich-3.2"      CHAINER_VER="3.5.0"
-  - MPI="mpich-3.2"      CHAINER_VER="4.0.0rc1"
+  - MPI="mpich-3.2"      CHAINER_VER="4.0.0"
   - MPI="openmpi-1.6.5"  CHAINER_VER="3.5.0"
-  - MPI="openmpi-1.6.5"  CHAINER_VER="4.0.0rc1"
+  - MPI="openmpi-1.6.5"  CHAINER_VER="4.0.0"
   - MPI="openmpi-1.10.3" CHAINER_VER="3.5.0"
-  - MPI="openmpi-1.10.3" CHAINER_VER="4.0.0rc1"
+  - MPI="openmpi-1.10.3" CHAINER_VER="4.0.0"
 
 cache:
   - pip

--- a/docs/source/installation/guide.rst
+++ b/docs/source/installation/guide.rst
@@ -110,8 +110,8 @@ We tested ChainerMN on all the following environments.
   * Ubuntu 14.04 LTS 64bit
 
 * Python 2.7.13 3.5.1 3.6.1
-* Chainer 3.5.0
-* CuPy 2.5.0
+* Chainer 3.5.0 4.0.0
+* CuPy 2.5.0 4.0.0
 * MPI
 
   * openmpi 1.6.5 1.10.3 2.1.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 install_requires = [
     'cffi',
-    'chainer >=3.3.0, !=4.0.0b2, != 4.0.0b1, != 4.0.0a1',
+    'chainer >=3.5.0, !=4.0.0b2, != 4.0.0b1, != 4.0.0a1',
     'mpi4py',
 ]
 


### PR DESCRIPTION
Chainer and CuPy 4.0.0 have been released today.