### PR TITLE
[WIP] Revert multi-node iterator

### DIFF
--- a/chainermn/communicators/communicator_base.py
+++ b/chainermn/communicators/communicator_base.py
@@ -153,6 +153,26 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         '''
         raise NotImplementedError()
 
+    @abstractmethod
+    def allgather(self, x):
+        """A primitive of inter-process all-gather communication.
+
+        This method tries to invoke all-gather communication within the
+        communicator. All processes in the communicator are expected to
+        invoke ``allgather()``. This method relies on mpi4py fast communication
+        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        Note that this method can only handle the same shapes of data
+        over all processes, and cannot handle tuple data.
+
+        Args:
+            x (numpy.array): Array to be gathered.
+
+        Returns:
+            ys (tuple of numpy.ndarray): Received arrays.
+        """
+        raise NotImplementedError()
+
     # TODO(kuenishi): implement this function in MpiCommunicatorBase
     # @abstractmethod
     def allreduce(self, data):

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -248,8 +248,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                 raise TypeError('Tuple data cannot be broadcasted')
 
             elif x.dtype != numpy.float32:
-                raise ValueError(
-                    'MPI broadcast only supports dtype == numpy.float32')
+                raise TypeError('bcast only supports dtype == numpy.float32')
 
             msgtype = self.mpi_comm.bcast(msgtype, root)
             shape = msgtype.shapes[0]
@@ -305,7 +304,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                         'gather cannot handle different shapes of data')
 
         if x.dtype != numpy.float32:
-            raise ValueError('gather only support dtype == numpy.float32')
+            raise TypeError('gather only supports dtype == numpy.float32')
 
         # Gather data.
         sbuf = _memory_utility.array_to_buffer_object(x)
@@ -335,6 +334,68 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
     def gather_obj(self, obj, root=0):
         return self.mpi_comm.gather(obj, root=root)
+
+    def scatter(self, x, root=0):
+        """A primitive of inter-process scatter communication.
+
+        This method tries to invoke scatter communication within the
+        communicator. All processes in the communicator are expected to
+        invoke ``scatter()``. This method relies on mpi4py fast communication
+        optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        Note that this method can only handle the same shapes of data
+        over all processes, and cannot handle tuple data.
+
+        Args:
+            x (numpy.array):
+                Array to be scattered with shape (#proc, [data-shape]).
+
+        Returns:
+            ys (numpy.ndarray):
+                Received arrays with shape ([data-shape]).
+        """
+        chainer.utils.experimental(
+            'chainermn.communicators.CommunicatorBase.scatter')
+
+        is_master = self.mpi_comm.rank == root
+
+        # Type check.
+        if is_master:
+            msgtype = _MessageType(x)
+
+            if msgtype.is_tuple:
+                raise TypeError('scatter cannot handle tuple data')
+
+            assert len(msgtype.shapes) == 1
+
+            if msgtype.shapes[0][0] != self.mpi_comm.size:
+                raise ValueError(
+                    'scatter received inconsistent number of inputs '
+                    'with communicator size')
+
+            if x.dtype != numpy.float32:
+                raise TypeError('scatter only support dtype == numpy.float32')
+
+            msgtype = _MessageType(x[0])
+
+        else:
+            msgtype = None
+
+        msgtype = self.mpi_comm.bcast(msgtype, root)
+        shape = msgtype.shapes[0]
+
+        # Scatter data.
+        if is_master:
+            sbuf = _memory_utility.array_to_buffer_object(x)
+        else:
+            sbuf = None
+        rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+        self.mpi_comm.Scatter(sbuf, rbuf, root)
+
+        return rbuf.reshape(shape)
+
+    def broadcast_data(self, model):
+        raise NotImplementedError()
 
     def allreduce_obj(self, obj):
         # Summation by default

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -272,17 +272,13 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         invoke ``gather()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
-        Note that this method can only handle the same shapes of data
-        over all processes, and cannot handle tuple data.
-
         Args:
             x (numpy.array): Array to be gathered.
             root (int): Rank of root process.
 
         Returns:
-            ys (numpy.ndarray):
-                Received arrays with shape (#proc, [data-shape]).
-                ``None`` for non-root processes.
+            ys (tuple of numpy.ndarray):
+                Received arrays. ``None`` for non-root processes.
         """
         chainer.utils.experimental(
             'chainermn.communicators.MpiCommunicatorBase.gather')
@@ -293,6 +289,9 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         msgtypes = self.mpi_comm.gather(msgtype, root)
 
         # Type check.
+        if x.dtype != numpy.float32:
+            raise TypeError('gather only support dtype == numpy.float32')
+
         if is_master:
             shape = msgtype.shapes[0]
             for msgtype in msgtypes:
@@ -301,29 +300,26 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
                 assert len(msgtype.shapes) == 1
 
-                if msgtype.shapes[0] != shape:
-                    raise ValueError(
-                        'gather cannot handle different shapes of data')
+            sbuf = _memory_utility.array_to_buffer_object(x)
+            shapes = [mty.shapes[0] for mty in msgtypes]
+            rlens = [numpy.prod(s) for s in shapes]
+            rbuf = numpy.empty(sum(rlens), dtype=numpy.float32)
 
-        if x.dtype != numpy.float32:
-            raise TypeError('gather only supports dtype == numpy.float32')
+            if chainer.cuda.get_array_module(x) is not numpy:
+                chainer.cuda.Stream.null.synchronize()
 
-        # Gather data.
-        sbuf = _memory_utility.array_to_buffer_object(x)
-        if is_master:
-            shape = tuple([self.mpi_comm.size]) + shape
-            rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+            self.mpi_comm.Gatherv(
+                sbuf,
+                [rbuf, (rlens, _cnt_to_dsp(rlens)), mpi4py.MPI.FLOAT],
+                root)
+
+            ys = [rbuf[i:i + l].reshape(s)
+                  for i, l, s in zip(_cnt_to_dsp(rlens), rlens, shapes)]
+            return tuple(ys)
+
         else:
-            rbuf = None
-
-        if chainer.cuda.get_array_module(x) is not numpy:
-            chainer.cuda.Stream.null.synchronize()
-
-        self.mpi_comm.Gather(sbuf, rbuf, root)
-
-        if is_master:
-            return rbuf.reshape(shape)
-        else:
+            sbuf = _memory_utility.array_to_buffer_object(x)
+            self.mpi_comm.Gatherv(sbuf, None, root)
             return None
 
     # Objects
@@ -382,7 +378,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                         'with communicator size')
 
                 msgtype = tuple([_MessageType(x) for x in xs])
-                shapes = [mt.shapes[0] for mt in msgtype]
+                shapes = [mty.shapes[0] for mty in msgtype]
                 xs = xp.hstack([x.reshape(-1) for x in xs])
 
             else:

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -361,7 +361,6 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         chainer.utils.experimental(
             'chainermn.communicators.CommunicatorBase.scatter')
 
-        xp = chainer.cuda.get_array_module(xs)
         is_master = self.mpi_comm.rank == root
 
         if is_master:
@@ -378,6 +377,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                         'the length of xs must be consistent '
                         'with communicator size')
 
+                xp = chainer.cuda.get_array_module(*xs)
                 msgtype = tuple([_MessageType(x) for x in xs])
                 shapes = [mty.shapes[0] for mty in msgtype]
                 # concatenate([x.reshape(-1) ... ], axis=0) will fail
@@ -396,6 +396,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                         'scatter received inconsistent number of inputs '
                         'with communicator size')
 
+                xp = chainer.cuda.get_array_module(xs)
                 msgtype = tuple([_MessageType(xs[0]) for _ in range(self.size)])
                 shapes = [xs.shape[1:] for _ in range(self.size)]
 

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -293,7 +293,6 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
             raise TypeError('gather only support dtype == numpy.float32')
 
         if is_master:
-            shape = msgtype.shapes[0]
             for msgtype in msgtypes:
                 if msgtype.is_tuple:
                     raise TypeError('gather cannot handle tuple data')
@@ -390,14 +389,14 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
                     raise TypeError(
                         'scatter only support dtype == numpy.float32')
 
-
                 if msgtype.shapes[0][0] != self.mpi_comm.size:
                     raise ValueError(
                         'scatter received inconsistent number of inputs '
                         'with communicator size')
 
                 xp = chainer.cuda.get_array_module(xs)
-                msgtype = tuple([_MessageType(xs[0]) for _ in range(self.size)])
+                msgtype = tuple([_MessageType(xs[0])
+                                 for _ in range(self.size)])
                 shapes = [xs.shape[1:] for _ in range(self.size)]
 
             msgtype = self.mpi_comm.scatter(msgtype, root)

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -233,6 +233,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
         Args:
             x (numpy.array): Array to be broadcasted.
+            root (int): Rank of root process.
 
         Returns:
             ys (tuple of numpy.ndarray): Received arrays.
@@ -276,6 +277,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
         Args:
             x (numpy.array): Array to be gathered.
+            root (int): Rank of root process.
 
         Returns:
             ys (numpy.ndarray):
@@ -349,6 +351,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         Args:
             x (numpy.array):
                 Array to be scattered with shape (#proc, [data-shape]).
+            root (int): Rank of root process.
 
         Returns:
             ys (numpy.ndarray):
@@ -393,9 +396,6 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         self.mpi_comm.Scatter(sbuf, rbuf, root)
 
         return rbuf.reshape(shape)
-
-    def broadcast_data(self, model):
-        raise NotImplementedError()
 
     def allreduce_obj(self, obj):
         # Summation by default

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -341,7 +341,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
     def gather_obj(self, obj, root=0):
         return self.mpi_comm.gather(obj, root=root)
 
-    def scatter(self, x, root=0):
+    def scatter(self, xs, root=0):
         """A primitive of inter-process scatter communication.
 
         This method tries to invoke scatter communication within the
@@ -349,59 +349,75 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         invoke ``scatter()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
-        Note that this method can only handle the same shapes of data
-        over all processes, and cannot handle tuple data.
+        If ``xs`` is tuple, each element is send to different processes.
+        The length of the tuple must be the same as the communicator size.
+        If ``xs`` is ``numpy.ndarrray``, it is splitted with the first
+        axis and sent to different processes. For slave processes, ``xs``
+        is allowed to be any value (will be ignored).
 
         Args:
-            x (numpy.array):
-                Array to be scattered with shape (#proc, [data-shape]).
+            xs (tuple of numpy.array or numpy.array): Arrays to be scattered.
             root (int): Rank of root process.
 
         Returns:
-            ys (numpy.ndarray):
-                Received arrays with shape ([data-shape]).
+            ys (numpy.ndarray): Received arrays.
         """
         chainer.utils.experimental(
             'chainermn.communicators.CommunicatorBase.scatter')
 
+        xp = chainer.cuda.get_array_module(xs)
         is_master = self.mpi_comm.rank == root
 
-        # Type check.
         if is_master:
-            msgtype = _MessageType(x)
-
-            if msgtype.is_tuple:
-                raise TypeError('scatter cannot handle tuple data')
-
-            assert len(msgtype.shapes) == 1
-
-            if msgtype.shapes[0][0] != self.mpi_comm.size:
-                raise ValueError(
-                    'scatter received inconsistent number of inputs '
-                    'with communicator size')
-
-            if x.dtype != numpy.float32:
+            # Type check.
+            if xs.dtype != numpy.float32:
                 raise TypeError('scatter only support dtype == numpy.float32')
 
-            msgtype = _MessageType(x[0])
+            msgtype = _MessageType(xs)
 
-        else:
-            msgtype = None
+            if msgtype.is_tuple:
+                if len(msgtype.shapes) != self.size:
+                    raise ValueError(
+                        'the length of xs must be consistent '
+                        'with communicator size')
 
-        msgtype = self.mpi_comm.bcast(msgtype, root)
-        shape = msgtype.shapes[0]
+                msgtype = tuple([_MessageType(x) for x in xs])
+                shapes = [mt.shapes[0] for mt in msgtype]
+                xs = xp.hstack([x.reshape(-1) for x in xs])
 
-        # Scatter data.
-        if is_master:
-            sbuf = _memory_utility.array_to_buffer_object(x)
-            if chainer.cuda.get_array_module(x) is not numpy:
+            else:
+                assert len(msgtype.shapes) == 1
+
+                if msgtype.shapes[0][0] != self.mpi_comm.size:
+                    raise ValueError(
+                        'scatter received inconsistent number of inputs '
+                        'with communicator size')
+
+                msgtype = tuple([_MessageType(xs[0]) for _ in range(self.size)])
+                shapes = [xs.shape[1:] for _ in range(self.size)]
+
+            msgtype = self.mpi_comm.scatter(msgtype, root)
+            shape = msgtype.shapes[0]
+
+            # Collective communication.
+            slens = [numpy.prod(s) for s in shapes]
+            sbuf = _memory_utility.array_to_buffer_object(xs)[0]
+            rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+            if xp is not numpy:
                 chainer.cuda.Stream.null.synchronize()
-        else:
-            sbuf = None
-        rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
-        self.mpi_comm.Scatter(sbuf, rbuf, root)
 
-        return rbuf.reshape(shape)
+            self.mpi_comm.Scatterv(
+                [sbuf, (slens, _cnt_to_dsp(slens)), mpi4py.MPI.FLOAT],
+                rbuf, root)
+
+            return rbuf.reshape(shape)
+
+        else:  # slave processes
+            msgtypes = self.mpi_comm.scatter(None, root)
+            shape = msgtypes.shapes[0]
+            rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
+            self.mpi_comm.Scatterv(None, rbuf, root)
+            return rbuf.reshape(shape)
 
     def allreduce_obj(self, obj):
         # Summation by default

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -315,6 +315,10 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
             rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)
         else:
             rbuf = None
+
+        if chainer.cuda.get_array_module(x) is not numpy:
+            chainer.cuda.Stream.null.synchronize()
+
         self.mpi_comm.Gather(sbuf, rbuf, root)
 
         if is_master:
@@ -390,6 +394,8 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         # Scatter data.
         if is_master:
             sbuf = _memory_utility.array_to_buffer_object(x)
+            if chainer.cuda.get_array_module(x) is not numpy:
+                chainer.cuda.Stream.null.synchronize()
         else:
             sbuf = None
         rbuf = numpy.empty(numpy.prod(shape), dtype=numpy.float32)

--- a/chainermn/functions/__init__.py
+++ b/chainermn/functions/__init__.py
@@ -1,5 +1,5 @@
-from chainermn.functions.collective_communication import all_gather  # NOQA
-from chainermn.functions.collective_communication import all_to_all  # NOQA
+from chainermn.functions.collective_communication import allgather  # NOQA
+from chainermn.functions.collective_communication import alltoall  # NOQA
 from chainermn.functions.collective_communication import bcast  # NOQA
 from chainermn.functions.collective_communication import gather  # NOQA
 from chainermn.functions.collective_communication import scatter  # NOQA

--- a/chainermn/functions/__init__.py
+++ b/chainermn/functions/__init__.py
@@ -1,3 +1,4 @@
+from chainermn.functions.collective_communication import all_gather  # NOQA
 from chainermn.functions.collective_communication import all_to_all  # NOQA
 from chainermn.functions.collective_communication import bcast  # NOQA
 from chainermn.functions.collective_communication import gather  # NOQA

--- a/chainermn/functions/__init__.py
+++ b/chainermn/functions/__init__.py
@@ -1,7 +1,7 @@
 from chainermn.functions.collective_communication import all_to_all  # NOQA
 from chainermn.functions.collective_communication import bcast  # NOQA
-from chainermn.functions.collective_communication import gather # NOQA
-from chainermn.functions.collective_communication import scatter # NOQA
+from chainermn.functions.collective_communication import gather  # NOQA
+from chainermn.functions.collective_communication import scatter  # NOQA
 
 from chainermn.functions.point_to_point_communication import recv  # NOQA
 from chainermn.functions.point_to_point_communication import send  # NOQA

--- a/chainermn/functions/__init__.py
+++ b/chainermn/functions/__init__.py
@@ -1,5 +1,9 @@
 from chainermn.functions.collective_communication import all_to_all  # NOQA
 from chainermn.functions.collective_communication import bcast  # NOQA
+from chainermn.functions.collective_communication import gather # NOQA
+from chainermn.functions.collective_communication import scatter # NOQA
+
 from chainermn.functions.point_to_point_communication import recv  # NOQA
 from chainermn.functions.point_to_point_communication import send  # NOQA
+
 from chainermn.functions.pseudo_connect import pseudo_connect  # NOQA

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -97,6 +97,9 @@ class Gather(chainer.Function):
         y = self.comm.gather(x, self.root)
 
         if self.comm.rank == self.root:
+            if isinstance(self.device, int) and self.device >= 0:
+                y = cuda.to_gpu(y, device=self.device)
+
             ys = tuple([y[0] for y in xp.split(y, self.comm.size, axis=0)])
             return ys
 
@@ -150,6 +153,9 @@ class Scatter(chainer.Function):
             y = self.comm.scatter(xs, self.root)
         else:
             y = self.comm.scatter(None, self.root)
+
+        if isinstance(self.device, int) and self.device >= 0:
+            y = cuda.to_gpu(y, device=self.device)
 
         return y,
 

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -203,7 +203,7 @@ class Scatter(chainer.Function):
                 return dummy_var
 
 
-def all_gather(comm, x, device=-1):
+def allgather(comm, x, device=-1):
     """Differentiable all-gather communication between workers.
 
     This function invokes gather communications among processes specified
@@ -223,7 +223,7 @@ def all_gather(comm, x, device=-1):
     return AllGather(comm, device)(x)
 
 
-def all_to_all(comm, xs, device=-1):
+def alltoall(comm, xs, device=-1):
     """Differentiable all-to-all communication between workers.
 
     This function invokes all-to-all communications among processes specified

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -82,6 +82,100 @@ class Bcast(chainer.Function):
                 return None,
 
 
+class Gather(chainer.Function):
+    """Collective gather communication."""
+
+    def __init__(self, comm, root, device):
+        chainer.utils.experimental('chainermn.functions.Gather')
+        self.comm = comm
+        self.root = root
+        self.device = device
+
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        x, = inputs
+        y = self.comm.gather(x, self.root)
+
+        if self.comm.rank == self.root:
+            ys = tuple([y[0] for y in xp.split(y, self.comm.size, axis=0)])
+            return ys
+
+        else:
+            # Return an empty variable, which serves as "delegate_variable."
+            return xp.array([], dtype=xp.float32),
+
+    def backward(self, inputs, grad_outputs):
+        xp = cuda.get_array_module(*inputs)
+        with cuda.get_device_from_array(*inputs):
+            if self.comm.rank == self.root:
+                gy = xp.stack(grad_outputs)
+            else:
+                gy = None
+
+            gx = self.comm.scatter(gy, self.root)
+
+            if isinstance(self.device, int) and self.device >= 0:
+                gx = cuda.to_gpu(gx, device=self.device)
+
+            return gx,
+
+
+class Scatter(chainer.Function):
+    """Collective scatter communication."""
+
+    def __init__(self, comm, root, device):
+        chainer.utils.experimental('chainermn.functions.Scatter')
+        self.comm = comm
+        self.root = root
+        self.device = device
+
+    def __call__(self, *inputs):
+        xp = cuda.get_array_module(*inputs)
+
+        if inputs == ():
+            # Without dummy variable, this function does not "require_grad",
+            # thus back propagation will not be invoked.
+            dummy_var = chainer.Variable(xp.array([], dtype=xp.float32))
+            dummy_var.name = 'dummy_var'
+            return super(Scatter, self).__call__(dummy_var)
+
+        else:
+            return super(Scatter, self).__call__(*inputs)
+
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+
+        if self.comm.rank == self.root:
+            xs = xp.stack(inputs)
+            y = self.comm.scatter(xs, self.root)
+        else:
+            y = self.comm.scatter(None, self.root)
+
+        return y,
+
+    def backward(self, inputs, grad_outputs):
+        xp = cuda.get_array_module(*inputs)
+        with cuda.get_device_from_array(*inputs):
+            gy, = grad_outputs
+            gys = self.comm.gather(gy, self.root)
+
+            if self.comm.rank == self.root:
+                if isinstance(self.device, int) and self.device >= 0:
+                    gys = cuda.to_gpu(gys, device=self.device)
+
+                gys = [gy[0] for gy in xp.split(gys, self.comm.size)]
+                return tuple(gys)
+
+            else:
+                # Slave processes need to maintain input/output shapes.
+                if inputs == ():
+                    dummy_var = tuple([xp.array([], dtype=xp.float32)])
+                else:
+                    dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32)
+                                       for x in inputs])
+                return dummy_var
+
+
 def all_to_all(comm, xs, device=-1):
     """Differentiable all-to-all communication between workers.
 
@@ -133,3 +227,50 @@ def bcast(comm, x, root=0, device=-1):
         return Bcast(comm, root, device)(x)
     else:
         return Bcast(comm, root, device)()
+
+
+def gather(comm, x, root=0, device=-1):
+    """Differentiable gather communication between workers.
+
+    This function invokes gather communications among processes specified
+    by the communicator. Backward will be invoked as well as the ordinary
+    chainer functions, where gradients are scattered from the root process
+    to each slave.
+
+    Args:
+        comm: ChainerMN communicator.
+        x (chainer.Variable): Variable to be sent.
+        device (int): Target device specifier.
+
+    Returns:
+        ys (chainer.Variable):
+            Gathered variables. ``None`` for slaves.
+    """
+    chainer.utils.experimental('chainermn.functions.gather')
+
+    return Gather(comm, root, device)(x)
+
+
+def scatter(comm, xs, root=0, device=-1):
+    """Differentiable scatter communication between workers.
+
+    This function invokes scatter communications among processes specified
+    by the communicator. Backward will be invoked as well as the ordinary
+    chainer functions, where gradients are gathered to the root process.
+
+    Args:
+        comm: ChainerMN communicator.
+        xs (list of chainer.Variable):
+            Variables to be scattered for master process.
+            ``None`` for slave process.
+        device (int): Target device specifier.
+
+    Returns:
+        y (chainer.Variable): Scattered variable.
+    """
+    chainer.utils.experimental('chainermn.functions.scatter')
+
+    if comm.rank == root:
+        return Scatter(comm, root, device)(*xs)
+    else:
+        return Scatter(comm, root, device)()

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -122,13 +122,13 @@ class Gather(chainer.Function):
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         x, = inputs
-        y = self.comm.gather(x, self.root)
+        ys = self.comm.gather(x, self.root)
 
         if self.comm.rank == self.root:
             if isinstance(self.device, int) and self.device >= 0:
-                y = cuda.to_gpu(y, device=self.device)
+                ys = cuda.to_gpu(ys, device=self.device)
 
-            ys = tuple([y[0] for y in xp.split(y, self.comm.size, axis=0)])
+            ys = tuple([y[0] for y in xp.split(ys, self.comm.size, axis=0)])
             return ys
 
         else:
@@ -191,14 +191,14 @@ class Scatter(chainer.Function):
         xp = cuda.get_array_module(*inputs)
         with cuda.get_device_from_array(*inputs):
             gy, = grad_outputs
-            gys = self.comm.gather(gy, self.root)
+            gxs = self.comm.gather(gy, self.root)
 
             if self.comm.rank == self.root:
                 if isinstance(self.device, int) and self.device >= 0:
-                    gys = cuda.to_gpu(gys, device=self.device)
+                    gxs = cuda.to_gpu(gxs, device=self.device)
 
-                gys = [gy[0] for gy in xp.split(gys, self.comm.size)]
-                return tuple(gys)
+                gxs = [gx[0] for gx in xp.split(gxs, self.comm.size)]
+                return tuple(gxs)
 
             else:
                 # Slave processes need to maintain input/output shapes.

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -97,11 +97,14 @@ class Bcast(chainer.Function):
         return x,
 
     def backward(self, inputs, grad_outputs):
+        xp = cuda.get_array_module(*inputs)
         with cuda.get_device_from_array(*inputs):
             gx, = grad_outputs
             gxs = self.comm.gather(gx, self.root)
 
             if self.comm.rank == self.root:
+                gxs = xp.stack(gxs)
+
                 if isinstance(self.device, int) and self.device >= 0:
                     gxs = cuda.to_gpu(gxs, device=self.device)
 
@@ -125,6 +128,8 @@ class Gather(chainer.Function):
         ys = self.comm.gather(x, self.root)
 
         if self.comm.rank == self.root:
+            ys = xp.stack(ys)
+
             if isinstance(self.device, int) and self.device >= 0:
                 ys = cuda.to_gpu(ys, device=self.device)
 
@@ -194,6 +199,8 @@ class Scatter(chainer.Function):
             gxs = self.comm.gather(gy, self.root)
 
             if self.comm.rank == self.root:
+                gxs = xp.stack(gxs)
+
                 if isinstance(self.device, int) and self.device >= 0:
                     gxs = cuda.to_gpu(gxs, device=self.device)
 

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -128,12 +128,9 @@ class Gather(chainer.Function):
         ys = self.comm.gather(x, self.root)
 
         if self.comm.rank == self.root:
-            ys = xp.stack(ys)
-
             if isinstance(self.device, int) and self.device >= 0:
-                ys = cuda.to_gpu(ys, device=self.device)
+                ys = tuple([cuda.to_gpu(y, device=self.device) for y in ys])
 
-            ys = tuple([y[0] for y in xp.split(ys, self.comm.size, axis=0)])
             return ys
 
         else:
@@ -143,12 +140,7 @@ class Gather(chainer.Function):
     def backward(self, inputs, grad_outputs):
         xp = cuda.get_array_module(*inputs)
         with cuda.get_device_from_array(*inputs):
-            if self.comm.rank == self.root:
-                gy = xp.stack(grad_outputs)
-            else:
-                gy = None
-
-            gx = self.comm.scatter(gy, self.root)
+            gx = self.comm.scatter(grad_outputs, self.root)
 
             if isinstance(self.device, int) and self.device >= 0:
                 gx = cuda.to_gpu(gx, device=self.device)
@@ -182,8 +174,7 @@ class Scatter(chainer.Function):
         xp = cuda.get_array_module(*inputs)
 
         if self.comm.rank == self.root:
-            xs = xp.stack(inputs)
-            y = self.comm.scatter(xs, self.root)
+            y = self.comm.scatter(inputs, self.root)
         else:
             y = self.comm.scatter(None, self.root)
 
@@ -199,13 +190,10 @@ class Scatter(chainer.Function):
             gxs = self.comm.gather(gy, self.root)
 
             if self.comm.rank == self.root:
-                gxs = xp.stack(gxs)
-
                 if isinstance(self.device, int) and self.device >= 0:
-                    gxs = cuda.to_gpu(gxs, device=self.device)
+                    gxs = tuple([cuda.to_gpu(gx, device=self.device) for gx in gxs])
 
-                gxs = [gx[0] for gx in xp.split(gxs, self.comm.size)]
-                return tuple(gxs)
+                return gxs
 
             else:
                 # Slave processes need to maintain input/output shapes.

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -15,7 +15,7 @@ class AllGather(chainer.Function):
         ys = self.comm.allgather(x)
 
         if isinstance(self.device, int) and self.device >= 0:
-            ys = cuda.to_gpu(ys, device=self.device)
+            ys = tuple([cuda.to_gpu(y, device=self.device) for y in ys])
 
         return ys
 
@@ -24,7 +24,7 @@ class AllGather(chainer.Function):
         gxs = self.comm.alltoall(grad_outputs)
 
         if isinstance(self.device, int) and self.device >= 0:
-            gxs = cuda.to_gpu(gxs, device=self.device)
+            gxs = tuple([cuda.to_gpu(gx, device=self.device) for gx in gxs])
 
         gx = xp.stack(gxs).sum(axis=0)
         return gx,

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -2,6 +2,34 @@ import chainer
 from chainer import cuda
 
 
+class AllGather(chainer.Function):
+    """Collective all-gather communication."""
+
+    def __init__(self, comm, device):
+        chainer.utils.experimental('chainermn.functions.AllGather')
+        self.comm = comm
+        self.device = device
+
+    def forward(self, inputs):
+        x, = inputs
+        ys = self.comm.allgather(x)
+
+        if isinstance(self.device, int) and self.device >= 0:
+            ys = cuda.to_gpu(ys, device=self.device)
+
+        return ys
+
+    def backward(self, inputs, grad_outputs):
+        xp = cuda.get_array_module(*inputs)
+        gxs = self.comm.alltoall(grad_outputs)
+
+        if isinstance(self.device, int) and self.device >= 0:
+            gxs = cuda.to_gpu(gxs, device=self.device)
+
+        gx = xp.stack(gxs).sum(axis=0)
+        return gx,
+
+
 class AllToAll(chainer.Function):
     """Collective all-to-all communication."""
 
@@ -180,6 +208,26 @@ class Scatter(chainer.Function):
                     dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32)
                                        for x in inputs])
                 return dummy_var
+
+
+def all_gather(comm, x, device=-1):
+    """Differentiable all-gather communication between workers.
+
+    This function invokes gather communications among processes specified
+    by the communicator. Backward will be invoked as well as the ordinary
+    chainer functions, where gradients are reduced to each process.
+
+    Args:
+        comm: ChainerMN communicator.
+        x (chainer.Variables): Variables to send.
+        device (int): Target device specifier.
+
+    Returns:
+        ys (list of chainer.Variables): Received variables.
+    """
+    chainer.utils.experimental('chainermn.functions.all_gather')
+
+    return AllGather(comm, device)(x)
 
 
 def all_to_all(comm, xs, device=-1):

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -1,5 +1,6 @@
 import chainer
 from chainer import cuda
+import numpy
 
 
 class AllGather(chainer.Function):
@@ -103,7 +104,7 @@ class Bcast(chainer.Function):
             gxs = self.comm.gather(gx, self.root)
 
             if self.comm.rank == self.root:
-                gxs = xp.stack(gxs)
+                gxs = numpy.stack(gxs)
 
                 if isinstance(self.device, int) and self.device >= 0:
                     gxs = cuda.to_gpu(gxs, device=self.device)

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -98,7 +98,6 @@ class Bcast(chainer.Function):
         return x,
 
     def backward(self, inputs, grad_outputs):
-        xp = cuda.get_array_module(*inputs)
         with cuda.get_device_from_array(*inputs):
             gx, = grad_outputs
             gxs = self.comm.gather(gx, self.root)
@@ -139,7 +138,6 @@ class Gather(chainer.Function):
             return xp.array([], dtype=xp.float32),
 
     def backward(self, inputs, grad_outputs):
-        xp = cuda.get_array_module(*inputs)
         with cuda.get_device_from_array(*inputs):
             gx = self.comm.scatter(grad_outputs, self.root)
 
@@ -172,8 +170,6 @@ class Scatter(chainer.Function):
             return super(Scatter, self).__call__(*inputs)
 
     def forward(self, inputs):
-        xp = cuda.get_array_module(*inputs)
-
         if self.comm.rank == self.root:
             y = self.comm.scatter(inputs, self.root)
         else:
@@ -192,7 +188,8 @@ class Scatter(chainer.Function):
 
             if self.comm.rank == self.root:
                 if isinstance(self.device, int) and self.device >= 0:
-                    gxs = tuple([cuda.to_gpu(gx, device=self.device) for gx in gxs])
+                    gxs = tuple([cuda.to_gpu(gx, device=self.device)
+                                 for gx in gxs])
 
                 return gxs
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -42,8 +42,11 @@ Functions
 .. autofunction:: chainermn.functions.send
 .. autofunction:: chainermn.functions.recv
 .. autofunction:: chainermn.functions.pseudo_connect
-.. autofunction:: chainermn.functions.all_to_all
 .. autofunction:: chainermn.functions.bcast
+.. autofunction:: chainermn.functions.gather
+.. autofunction:: chainermn.functions.scatter
+.. autofunction:: chainermn.functions.all_to_all
+.. autofunction:: chainermn.functions.all_gather
 
 
 Iterators

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -27,7 +27,7 @@ class TestCollectiveCommunication(unittest.TestCase):
 
     def check_all_gather(self, xs):
         x = xs[self.communicator.rank]
-        ys = chainermn.functions.all_gather(self.communicator, x, self.device)
+        ys = chainermn.functions.allgather(self.communicator, x, self.device)
         e = 0
         for i, y in enumerate(ys):
             e += chainer.functions.mean_squared_error(y, xs[i])
@@ -55,7 +55,7 @@ class TestCollectiveCommunication(unittest.TestCase):
         self.check_all_gather(xs)
 
     def check_all_to_all(self, xs):
-        ys = chainermn.functions.all_to_all(self.communicator, xs, self.device)
+        ys = chainermn.functions.alltoall(self.communicator, xs, self.device)
 
         y = chainer.functions.sum(ys[0])
         for _y in ys[1:]:

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -12,6 +12,8 @@ import chainermn.functions
 class TestCollectiveCommunication(unittest.TestCase):
 
     def setup(self, gpu):
+        numpy.random.seed(42)
+
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
             self.device = self.communicator.intra_rank
@@ -85,3 +87,78 @@ class TestCollectiveCommunication(unittest.TestCase):
             numpy.random.normal(size=(100, 100)).astype(numpy.float32))
         x.to_gpu()
         self.check_bcast(x)
+
+    def check_gather(self, xs):
+        root = 0
+        # All processes receive the same xs since seed is fixed.
+        x = xs[self.communicator.rank]
+
+        if self.communicator.rank == root:
+            ys = chainermn.functions.gather(
+                self.communicator, x, root, self.device)
+            e = 0
+            for i, y in enumerate(ys):
+                e += chainer.functions.mean_squared_error(y, xs[i])
+            e.backward()
+
+            # Check backward does not fall in deadlock, and error = 0.
+            self.assertEqual(e.data, 0)
+            self.assertEqual(e.grad, 1)
+
+        else:
+            phi = chainermn.functions.gather(
+                self.communicator, x, root, self.device)
+            phi.backward()
+
+            # Check backward does not fall in deadlock.
+            self.assertTrue(x.grad is not None)
+
+    def test_gather_cpu(self):
+        self.setup(False)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(100, 100)).astype(numpy.float32))
+            for _ in range(self.communicator.size)]
+        self.check_gather(xs)
+
+    @chainer.testing.attr.gpu
+    def test_gather_gpu(self):
+        self.setup(True)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(100, 100)).astype(numpy.float32))
+            for _ in range(self.communicator.size)]
+        for x in xs:
+            x.to_gpu()
+        self.check_gather(xs)
+
+    def check_scatter(self, xs):
+        # All processes receive the same xs since seed is fixed.
+        root = 0
+
+        y = chainermn.functions.scatter(
+            self.communicator,
+            xs if self.communicator.rank == root else None,
+            root, self.device)
+        x = xs[self.communicator.rank]
+        e = chainer.functions.mean_squared_error(y, x)
+        e.backward()
+
+        # Check backward does not fall in deadlock, and error = 0.
+        self.assertEqual(e.data, 0)
+        self.assertEqual(e.grad, 1)
+
+    def test_scatter_cpu(self):
+        self.setup(False)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(100, 100)).astype(numpy.float32))
+            for _ in range(self.communicator.size)]
+        self.check_scatter(xs)
+
+    @chainer.testing.attr.gpu
+    def test_scatter_gpu(self):
+        self.setup(True)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(100, 100)).astype(numpy.float32))
+            for _ in range(self.communicator.size)]
+        for x in xs:
+            x.to_gpu()
+        self.check_scatter(xs)

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -159,6 +159,23 @@ class TestCollectiveCommunication(unittest.TestCase):
             x.to_gpu()
         self.check_gather(xs)
 
+    def test_gatherv_cpu(self):
+        self.setup(False)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(i + 1, i + 1)).astype(numpy.float32))
+            for i in range(self.communicator.size)]
+        self.check_gather(xs)
+
+    @chainer.testing.attr.gpu
+    def test_gatherv_gpu(self):
+        self.setup(True)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(i + 1, i + 1)).astype(numpy.float32))
+            for i in range(self.communicator.size)]
+        for x in xs:
+            x.to_gpu()
+        self.check_gather(xs)
+
     def check_scatter(self, xs):
         # All processes receive the same xs since seed is fixed.
         root = 0
@@ -188,6 +205,23 @@ class TestCollectiveCommunication(unittest.TestCase):
         xs = [chainer.Variable(
             numpy.random.normal(size=(100, 100)).astype(numpy.float32))
             for _ in range(self.communicator.size)]
+        for x in xs:
+            x.to_gpu()
+        self.check_scatter(xs)
+
+    def test_scatterv_cpu(self):
+        self.setup(False)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(i + 1, i + 1)).astype(numpy.float32))
+            for i in range(self.communicator.size)]
+        self.check_scatter(xs)
+
+    @chainer.testing.attr.gpu
+    def test_scatterv_gpu(self):
+        self.setup(True)
+        xs = [chainer.Variable(
+            numpy.random.normal(size=(i + 1, i + 1)).astype(numpy.float32))
+            for i in range(self.communicator.size)]
         for x in xs:
             x.to_gpu()
         self.check_scatter(xs)


### PR DESCRIPTION
As our internal tests failing at current master, all of those tests failing at `test_multi_node_iterator` so try to separate test failure and make master branch clean again. Most test failure are like this:

```
chainermn_tests/iterators_tests/test_multi_node_iterator.py::TestMultiNodeIterator_param_0::test_mn_iterator 
chainermn_tests/iterators_tests/test_multi_node_iterator.py::TestMultiNodeIterator_param_1::test_mn_iterator [f58ef00bba8e:00234] *** Process received signal ***
[f58ef00bba8e:00234] Signal: Segmentation fault (11)
[f58ef00bba8e:00234] Signal code: Address not mapped (1)
[f58ef00bba8e:00234] Failing at address: 0x2d45488
```

CC: #186, #242, #226 .