### PR TITLE
Fix tests of MultiNodeIterator

### DIFF
--- a/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
+++ b/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
@@ -7,6 +7,7 @@
 #      iterators_tests/test_iterator_compatibility.py (7e8f6cc)
 
 import numpy
+import platform
 import pytest
 import unittest
 
@@ -55,6 +56,9 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 class TestIteratorCompatibility(unittest.TestCase):
 
     def setUp(self):
+        if self.iterator_class == chainer.iterators.MultiprocessIterator and \
+                        int(platform.python_version_tuple()[0]) < 3:
+            pytest.skip('This test requires Python version >= 3')
         self.communicator = chainermn.create_communicator('naive')
 
         if self.communicator.size < 2:

--- a/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
+++ b/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
@@ -57,7 +57,7 @@ class TestIteratorCompatibility(unittest.TestCase):
 
     def setUp(self):
         if self.iterator_class == chainer.iterators.MultiprocessIterator and \
-                        int(platform.python_version_tuple()[0]) < 3:
+                int(platform.python_version_tuple()[0]) < 3:
             pytest.skip('This test requires Python version >= 3')
         self.communicator = chainermn.create_communicator('naive')
 

--- a/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
+++ b/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
@@ -50,7 +50,7 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 
 @chainer.testing.parameterize(
     {'iterator_class': chainer.iterators.SerialIterator},
-    {'iterator_class': chainer.iterators.MultiprocessIterator},
+    #{'iterator_class': chainer.iterators.MultiprocessIterator},
 )
 class TestIteratorCompatibility(unittest.TestCase):
 

--- a/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
+++ b/tests/chainermn_tests/iterators_tests/test_iterator_compatibility.py
@@ -50,7 +50,7 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 
 @chainer.testing.parameterize(
     {'iterator_class': chainer.iterators.SerialIterator},
-    #{'iterator_class': chainer.iterators.MultiprocessIterator},
+    {'iterator_class': chainer.iterators.MultiprocessIterator},
 )
 class TestIteratorCompatibility(unittest.TestCase):
 

--- a/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
+++ b/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
@@ -43,7 +43,7 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 
 @chainer.testing.parameterize(
     {'iterator_class': chainer.iterators.SerialIterator},
-    {'iterator_class': chainer.iterators.MultiprocessIterator},
+    #{'iterator_class': chainer.iterators.MultiprocessIterator},
 )
 class TestMultiNodeIterator(unittest.TestCase):
 

--- a/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
+++ b/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
@@ -50,7 +50,7 @@ class TestMultiNodeIterator(unittest.TestCase):
 
     def setUp(self):
         if self.iterator_class == chainer.iterators.MultiprocessIterator and \
-                        int(platform.python_version_tuple()[0]) < 3:
+                int(platform.python_version_tuple()[0]) < 3:
             pytest.skip('This test requires Python version >= 3')
         self.communicator = chainermn.create_communicator('naive')
 

--- a/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
+++ b/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
@@ -43,7 +43,7 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 
 @chainer.testing.parameterize(
     {'iterator_class': chainer.iterators.SerialIterator},
-    #{'iterator_class': chainer.iterators.MultiprocessIterator},
+    {'iterator_class': chainer.iterators.MultiprocessIterator},
 )
 class TestMultiNodeIterator(unittest.TestCase):
 

--- a/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
+++ b/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
@@ -3,6 +3,7 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 import numpy as np
+import platform
 import pytest
 from six.moves import range
 import unittest
@@ -48,6 +49,9 @@ class DummyDeserializer(chainer.serializer.Deserializer):
 class TestMultiNodeIterator(unittest.TestCase):
 
     def setUp(self):
+        if self.iterator_class == chainer.iterators.MultiprocessIterator and \
+                        int(platform.python_version_tuple()[0]) < 3:
+            pytest.skip('This test requires Python version >= 3')
         self.communicator = chainermn.create_communicator('naive')
 
         if self.communicator.size < 2:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,14 @@ import multiprocessing
 import pytest
 
 
+def dummy_func():
+    pass
+
 @pytest.fixture(scope='session', autouse=True)
 def scope_session():
-    print("setup before session")
     multiprocessing.set_start_method('forkserver')
     # TODO make this silent
-    p = multiprocessing.Process(target=print, args=('Initialize forkserver',))
+    p = multiprocessing.Process(target=dummy_func)
     p.start()
     p.join()
     yield
-    print("teardown after session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def dummy_func():
 
 @pytest.fixture(scope='session', autouse=True)
 def scope_session():
-    if platform.python_version_tuple()[0] >= 3:
+    if int(platform.python_version_tuple()[0]) >= 3:
         multiprocessing.set_start_method('forkserver')
         p = multiprocessing.Process(target=dummy_func)
         p.start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import multiprocessing
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def scope_session():
+    print("setup before session")
+    multiprocessing.set_start_method('forkserver')
+    # TODO make this silent
+    p = multiprocessing.Process(target=print, args=('Initialize forkserver',))
+    p.start()
+    p.join()
+    yield
+    print("teardown after session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import platform
 import pytest
 
 
@@ -8,8 +9,9 @@ def dummy_func():
 
 @pytest.fixture(scope='session', autouse=True)
 def scope_session():
-    multiprocessing.set_start_method('forkserver')
-    p = multiprocessing.Process(target=dummy_func)
-    p.start()
-    p.join()
+    if platform.python_version_tuple()[0] >= 3:
+        multiprocessing.set_start_method('forkserver')
+        p = multiprocessing.Process(target=dummy_func)
+        p.start()
+        p.join()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 def dummy_func():
     pass
 
+
 @pytest.fixture(scope='session', autouse=True)
 def scope_session():
     multiprocessing.set_start_method('forkserver')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ def dummy_func():
 @pytest.fixture(scope='session', autouse=True)
 def scope_session():
     multiprocessing.set_start_method('forkserver')
-    # TODO make this silent
     p = multiprocessing.Process(target=dummy_func)
     p.start()
     p.join()


### PR DESCRIPTION
Our internal tests failed at current master. Most test failure are like this:
```
chainermn_tests/iterators_tests/test_multi_node_iterator.py::TestMultiNodeIterator_param_0::test_mn_iterator 
chainermn_tests/iterators_tests/test_multi_node_iterator.py::TestMultiNodeIterator_param_1::test_mn_iterator [f58ef00bba8e:00234] *** Process received signal ***
[f58ef00bba8e:00234] Signal: Segmentation fault (11)
[f58ef00bba8e:00234] Signal code: Address not mapped (1)
[f58ef00bba8e:00234] Failing at address: 0x2d45488
```

Its cause was that we did not use forkserver when using MultiProcessIterator.When using multiprocess and InfiniBand, segmentation fault sometimes occurs if forkserver is not used.

To solve this problem, I use forkserver.