### PR TITLE
Fix MultiNodeIterator for paired datasets

### DIFF
--- a/chainermn/iterators/multi_node_iterator.py
+++ b/chainermn/iterators/multi_node_iterator.py
@@ -2,45 +2,67 @@ import chainer
 import numpy
 
 
-class _MultiNodeIterator_Master(object):
+class _MultiNodeIterator_Master(chainer.dataset.iterator.Iterator):
 
     def __init__(self, actual_iterator, communicator, rank_master):
-        self.communicator = communicator
-        self.rank_master = rank_master
-        self.actual_iterator = actual_iterator
+        super(_MultiNodeIterator_Master, self).__setattr__(
+            'communicator', communicator)
+        super(_MultiNodeIterator_Master, self).__setattr__(
+            'actual_iterator', actual_iterator)
+        super(_MultiNodeIterator_Master, self).__setattr__(
+            'rank_master', rank_master)
 
         _dataset_size = numpy.ones((1, )).astype(numpy.float32) \
             * len(self.actual_iterator.dataset)
         # TODO(tsutsumi): potential deadlock?
         self.communicator.bcast(_dataset_size, root=self.rank_master)
-        self.communicator.bcast(
-            self.actual_iterator._order.astype(numpy.float32),
-            root=self.rank_master)
+        if self.actual_iterator._order is not None:
+            self.communicator.bcast(
+                self.actual_iterator._order.astype(numpy.float32),
+                root=self.rank_master)
+        else:
+            # Without shuffle, order is None.
+            self.communicator.bcast(
+                -numpy.ones((1, )).astype(numpy.float32),
+                root=self.rank_master)
 
     def __next__(self):
         try:
             batch = self.actual_iterator.__next__()
             stop = False
+            is_paired_dataset = isinstance(batch, list) \
+                and isinstance(batch[0], tuple) and len(batch[0]) == 2
         except StopIteration:
             stop = True
+            is_paired_dataset = False
+
         is_new_epoch = self.actual_iterator.is_new_epoch
 
         # Notify the followings to slave iterators:
         # 1. whether stop signal is received before broadcasting data.
-        # 2. is_new_epoch.
-        # 3. current_position.
-        _info = numpy.ones((3, )) \
-            * [int(stop),
+        # 2. whether dataset is paired.
+        # 3. is_new_epoch.
+        # 4. current_position.
+        _info = numpy.ones((4, )) \
+            * [int(stop), int(is_paired_dataset),
                int(is_new_epoch),
                int(self.actual_iterator.current_position)]
         _info = _info.astype(numpy.float32)
         self.communicator.bcast(_info, root=self.rank_master)
 
         if not stop:
-            if isinstance(batch, list):
-                batch = numpy.array(batch)
-            batch = self.communicator.bcast(batch, root=self.rank_master)
-            return batch.tolist()
+            if is_paired_dataset:
+                _xs, _ys = zip(*batch)
+                xs = numpy.asarray(_xs, dtype=numpy.float32)
+                ys = numpy.asarray(_ys, dtype=numpy.float32)
+                self.communicator.bcast(xs, root=self.rank_master)
+                self.communicator.bcast(ys, root=self.rank_master)
+                return batch
+            else:
+                if isinstance(batch, list):
+                    batch = numpy.array(batch)
+                batch = self.communicator.bcast(batch, root=self.rank_master)
+                return batch.tolist()
         else:
             raise StopIteration
 
@@ -51,6 +73,18 @@ class _MultiNodeIterator_Master(object):
 
     def __setattr_(self, attr_name, value):
         setattr(self.actual_iterator, attr_name, value)
+
+    @property
+    def current_position(self):
+        return self.actual_iterator.current_position
+
+    @property
+    def epoch_detail(self):
+        return self.actual_iterator.epoch_detail
+
+    @property
+    def is_new_epoch(self):
+        return self.actual_iterator.is_new_epoch
 
     def serialize(self, serializer):
         # Master's and Slave's serialize must be called at the same time.
@@ -76,20 +110,28 @@ class _MultiNodeIterator_Slave(chainer.dataset.iterator.Iterator):
         self.dataset_size = int(_size)
         self._order = self.communicator.bcast(None, root=self.rank_master)
         self._order = self._order.astype(numpy.int64)
+        if self._order[0] == -1:
+            self._order = None
 
     def __next__(self):
         # Check if master iterator received stop signal.
         _info = self.communicator.bcast(None, root=self.rank_master)
         stop = bool(_info[0])
-        self.is_new_epoch = bool(_info[1])
-        self.current_position = int(_info[2])
+        is_paired_dataset = bool(_info[1])
+        self.is_new_epoch = bool(_info[2])
+        self.current_position = int(_info[3])
 
         if self.is_new_epoch:
             self.epoch += 1
 
         if not stop:
-            batch = self.communicator.bcast(None, root=self.rank_master)
-            return batch.tolist()
+            if is_paired_dataset:
+                xs = self.communicator.bcast(None, root=self.rank_master)
+                ys = self.communicator.bcast(None, root=self.rank_master)
+                return list(zip(xs, ys.astype(numpy.int32)))
+            else:
+                batch = self.communicator.bcast(None, root=self.rank_master)
+                return batch.tolist()
         else:
             raise StopIteration
 

--- a/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
+++ b/tests/chainermn_tests/iterators_tests/test_multi_node_iterator.py
@@ -41,10 +41,13 @@ class DummyDeserializer(chainer.serializer.Deserializer):
         return value
 
 
-@chainer.testing.parameterize(
-    {'iterator_class': chainer.iterators.SerialIterator},
-    {'iterator_class': chainer.iterators.MultiprocessIterator},
-)
+@chainer.testing.parameterize(*chainer.testing.product({
+    'paired_dataset': [True, False],
+    'iterator_class': [
+        chainer.iterators.SerialIterator,
+        chainer.iterators.MultiprocessIterator
+    ],
+}))
 class TestMultiNodeIterator(unittest.TestCase):
 
     def setUp(self):
@@ -54,7 +57,12 @@ class TestMultiNodeIterator(unittest.TestCase):
             pytest.skip("This test is for multinode only")
 
         self.N = 100
-        self.dataset = np.arange(self.N).astype(np.float32)
+        if self.paired_dataset:
+            self.dataset = list(zip(
+                np.arange(self.N).astype(np.float32),
+                np.arange(self.N).astype(np.float32)))
+        else:
+            self.dataset = np.arange(self.N).astype(np.float32)
 
     def test_mn_iterator(self):
         # Datasize is a multiple of batchsize.


### PR DESCRIPTION
The old `MultiNodeIterator` fails to handle paired datasets, i.e.,
```
[(x1, y1), (x2, y2), ... , (xN, yN)]
```
In this implementation, first the master process confirms whether the dataset is paired or not, and broadcast twice (for the sequence `[x1, x2, ... , xN]` and `[y1, y2, ... , yN]`) in paired case.