### PR TITLE
Remove unused nccl comm and mpi comm

### DIFF
--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -56,24 +56,6 @@ def init_ranks(mpi_comm):
     return my_ranks
 
 
-def init_comms(mpi_comm, intra_rank, intra_size, inter_rank, use_nccl=True):
-    intra_mpi_comm = mpi_comm.Split(inter_rank, intra_rank)
-    inter_mpi_comm = mpi_comm.Split(intra_rank, inter_rank)
-    if use_nccl:
-        from chainermn import nccl
-        intra_nccl_comm_id = intra_mpi_comm.bcast(nccl.get_unique_id())
-        intra_nccl_comm = nccl.NcclCommunicator(
-            intra_size, intra_nccl_comm_id, intra_rank)
-        if nccl.get_version() >= 2000:
-            nccl_comm_id = mpi_comm.bcast(nccl.get_unique_id())
-            nccl_comm = nccl.NcclCommunicator(
-                mpi_comm.size, nccl_comm_id, mpi_comm.rank)
-        else:
-            nccl_comm = None
-        return intra_mpi_comm, inter_mpi_comm, intra_nccl_comm, nccl_comm
-    else:
-        return intra_mpi_comm, inter_mpi_comm
-
 def init_intra_mpi_comm(mpi_comm, intra_rank, inter_rank):
     return mpi_comm.Split(inter_rank, intra_rank)
 

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -74,6 +74,23 @@ def init_comms(mpi_comm, intra_rank, intra_size, inter_rank, use_nccl=True):
     else:
         return intra_mpi_comm, inter_mpi_comm
 
+def init_intra_mpi_comm(mpi_comm, intra_rank, inter_rank):
+    return mpi_comm.Split(inter_rank, intra_rank)
+
+
+def init_inter_mpi_comm(mpi_comm, intra_rank, inter_rank):
+    return mpi_comm.Split(intra_rank, inter_rank)
+
+
+def init_nccl_comm(mpi_comm):
+    from chainermn import nccl
+    if mpi_comm.rank == 0:
+        nccl_comm_id = nccl.get_unique_id()
+    else:
+        nccl_comm_id = None
+    nccl_comm_id = mpi_comm.bcast(nccl_comm_id)
+    return nccl.NcclCommunicator(mpi_comm.size, nccl_comm_id, mpi_comm.rank)
+
 
 def inter_allreduce_gpu(
         inter_mpi_comm, size, gpu_buffer_a, gpu_buffer_b,

--- a/chainermn/communicators/dummy_communicator.py
+++ b/chainermn/communicators/dummy_communicator.py
@@ -11,13 +11,11 @@ class DummyCommunicator(mpi_communicator_base.MpiCommunicatorBase):
     """
 
     def __init__(self, mpi_comm):
-        super(DummyCommunicator, self).__init__(mpi_comm, use_nccl=True)
+        super(DummyCommunicator, self).__init__(mpi_comm)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
 
     def allreduce_grad(self, model):
-        self._init_comms()
-
         params = _memory_utility.extract_params(model)
         itemsize = 4
         n_elems_total = sum(param.grad.size for param in params)

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -7,14 +7,12 @@ from chainermn.communicators import mpi_communicator_base
 class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
-        super(FlatCommunicator, self).__init__(mpi_comm, False)
+        super(FlatCommunicator, self).__init__(mpi_comm)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
 
     def allreduce_grad(self, model):
-        self._init_comms()
-
         params = _memory_utility.extract_params(model)
         itemsize = 4
         n_elems_total = sum(param.grad.size for param in params)

--- a/chainermn/communicators/hierarchical_communicator.py
+++ b/chainermn/communicators/hierarchical_communicator.py
@@ -10,9 +10,34 @@ from chainermn import nccl
 class HierarchicalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
-        super(HierarchicalCommunicator, self).__init__(mpi_comm, use_nccl=True)
+        super(HierarchicalCommunicator, self).__init__(mpi_comm)
+        if not nccl._available:
+            raise RuntimeError(
+                'NCCL is not available. '
+                'Please confirm that NCCL is enabled in CuPy.'
+            )
+
+        # We have to delay the initialization of communicators. This is because
+        # NCCL's communicators use the current CUDA devices at the time of
+        # initialization. Therefore, we have to initialize NCCL communicators
+        # after users set the devices to use.
+        self.inter_mpi_comm = None
+        self.intra_nccl_comm = None
+
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
+
+    def _init_comms(self):
+        if self.inter_mpi_comm is not None:
+            assert self.intra_nccl_comm is not None
+            return
+
+        intra_mpi_comm = _communication_utility.init_intra_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.inter_mpi_comm = _communication_utility.init_inter_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.intra_nccl_comm = _communication_utility.init_nccl_comm(
+            intra_mpi_comm)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -9,7 +9,6 @@ from chainermn.communicators import _communication_utility
 from chainermn.communicators._communication_utility import chunked_bcast_obj
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import communicator_base
-from chainermn import nccl
 
 
 def _cnt_to_dsp(cnt):
@@ -48,26 +47,9 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
     '''
 
-    def __init__(self, mpi_comm, use_nccl=False):
+    def __init__(self, mpi_comm):
         self.mpi_comm = mpi_comm
         self._init_ranks()
-
-        if use_nccl and not nccl._available:
-            raise RuntimeError(
-                'NCCL is not available. '
-                'Please confirm that NCCL is enabled in CuPy.'
-            )
-
-        self.use_nccl = use_nccl
-
-        # We have to delay the initialization of communicators. This is because
-        # NCCL's communicators use the current CUDA devices at the time of
-        # initialization. Therefore, we have to initialize NCCL communicators
-        # after users set the devices to use.
-        self.inter_mpi_comm = None
-        self.intra_mpi_comm = None
-        if self.use_nccl:
-            self.intra_nccl_comm = None
 
     @property
     def rank(self):
@@ -353,17 +335,3 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         self.intra_size = my_ranks[2]
         self.inter_rank = my_ranks[3]
         self.inter_size = my_ranks[4]
-
-    def _init_comms(self):
-        if self.inter_mpi_comm is not None:
-            assert self.intra_mpi_comm is not None
-            assert not self.use_nccl or self.intra_nccl_comm is not None
-            return
-
-        comms = _communication_utility.init_comms(
-            self.mpi_comm, self.intra_rank, self.intra_size, self.inter_rank,
-            use_nccl=self.use_nccl)
-        self.intra_mpi_comm = comms[0]
-        self.inter_mpi_comm = comms[1]
-        if self.use_nccl:
-            self.intra_nccl_comm = comms[2]

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -2,6 +2,7 @@ import chainer.cuda
 import math
 import mpi4py.MPI
 
+from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
@@ -10,11 +11,36 @@ from chainermn import nccl
 class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
-        super(NonCudaAwareCommunicator, self).__init__(mpi_comm, use_nccl=True)
+        super(NonCudaAwareCommunicator, self).__init__(mpi_comm)
+        if not nccl._available:
+            raise RuntimeError(
+                'NCCL is not available. '
+                'Please confirm that NCCL is enabled in CuPy.'
+            )
+
+        # We have to delay the initialization of communicators. This is because
+        # NCCL's communicators use the current CUDA devices at the time of
+        # initialization. Therefore, we have to initialize NCCL communicators
+        # after users set the devices to use.
+        self.inter_mpi_comm = None
+        self.intra_nccl_comm = None
+
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
         self.cpu_buffer_a = _memory_utility.HostPinnedMemory()
         self.cpu_buffer_b = _memory_utility.HostPinnedMemory()
+
+    def _init_comms(self):
+        if self.inter_mpi_comm is not None:
+            assert self.intra_nccl_comm is not None
+            return
+
+        intra_mpi_comm = _communication_utility.init_intra_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.inter_mpi_comm = _communication_utility.init_inter_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.intra_nccl_comm = _communication_utility.init_nccl_comm(
+            intra_mpi_comm)
 
     def bcast_data(self, model):
         for _, param in sorted(model.namedparams()):

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -29,8 +29,7 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
 
     def _init_comms(self):
-        if self.intra_mpi_comm is not None:
-            assert self.intra_nccl_comm is not None
+        if self.intra_nccl_comm is not None:
             return
 
         intra_mpi_comm = _communication_utility.init_intra_mpi_comm(

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -1,5 +1,6 @@
 import chainer.cuda
 
+from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import mpi_communicator_base
 from chainermn import nccl
@@ -8,14 +9,34 @@ from chainermn import nccl
 class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm):
-        super(SingleNodeCommunicator, self).__init__(mpi_comm, use_nccl=True)
+        super(SingleNodeCommunicator, self).__init__(mpi_comm)
 
         if self.inter_size != 1:
             raise ValueError('SingleNodeCommunicator cannot be used under '
                              'multi-node settings')
+        if not nccl._available:
+            raise RuntimeError(
+                'NCCL is not available. '
+                'Please confirm that NCCL is enabled in CuPy.'
+            )
+        # We have to delay the initialization of communicators. This is because
+        # NCCL's communicators use the current CUDA devices at the time of
+        # initialization. Therefore, we have to initialize NCCL communicators
+        # after users set the devices to use.
+        self.intra_nccl_comm = None
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
+
+    def _init_comms(self):
+        if self.intra_mpi_comm is not None:
+            assert self.intra_nccl_comm is not None
+            return
+
+        intra_mpi_comm = _communication_utility.init_intra_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.intra_nccl_comm = _communication_utility.init_nccl_comm(
+            intra_mpi_comm)
 
     def bcast_data(self, model):
         self._init_comms()

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -12,9 +12,34 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
     def __init__(self, mpi_comm=mpi4py.MPI.COMM_WORLD):
         super(TwoDimensionalCommunicator, self).__init__(
-            mpi_comm, use_nccl=True)
+            mpi_comm)
+        if not nccl._available:
+            raise RuntimeError(
+                'NCCL is not available. '
+                'Please confirm that NCCL is enabled in CuPy.'
+            )
+
+        # We have to delay the initialization of communicators. This is because
+        # NCCL's communicators use the current CUDA devices at the time of
+        # initialization. Therefore, we have to initialize NCCL communicators
+        # after users set the devices to use.
+        self.inter_mpi_comm = None
+        self.intra_nccl_comm = None
+
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
+
+    def _init_comms(self):
+        if self.inter_mpi_comm is not None:
+            assert self.intra_nccl_comm is not None
+            return
+
+        intra_mpi_comm = _communication_utility.init_intra_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.inter_mpi_comm = _communication_utility.init_inter_mpi_comm(
+            self.mpi_comm, self.intra_rank, self.inter_rank)
+        self.intra_nccl_comm = _communication_utility.init_nccl_comm(
+            intra_mpi_comm)
 
     def allreduce_grad(self, model):
         self._init_comms()

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -231,6 +231,8 @@ def check_collective_communication(param, use_gpu):
     check_bcast_data(communicator, model)
     check_allreduce_grad(communicator, model)
     check_allreduce_grad_empty(communicator, model)
+    # barrier() requires before destructor of PureNcclCommunicator
+    # because communication may not be finished.
     communicator.mpi_comm.barrier()
 
 

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -231,6 +231,7 @@ def check_collective_communication(param, use_gpu):
     check_bcast_data(communicator, model)
     check_allreduce_grad(communicator, model)
     check_allreduce_grad_empty(communicator, model)
+    communicator.mpi_comm.barrier()
 
 
 # chainer.testing.parameterize is not available at functions

--- a/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
+++ b/tests/chainermn_tests/communicator_tests/test_node_aware_communicator_base.py
@@ -10,7 +10,7 @@ from chainermn.communicators.mpi_communicator_base import MpiCommunicatorBase
 
 class NodeAwareNaiveCommunicator(MpiCommunicatorBase):
     def __init__(self, mpi_comm):
-        super(NodeAwareNaiveCommunicator, self).__init__(mpi_comm, False)
+        super(NodeAwareNaiveCommunicator, self).__init__(mpi_comm)
 
     def allreduce_grad(self, model):
         raise NotImplementedError()

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -85,6 +85,7 @@ class TestDoubleBufferingOptimizer(unittest.TestCase):
         chainer.testing.assert_allclose(
             self.optimizer.communicated_target.c.W.grad,
             (base + 5) * np.ones((5, 4)))
+        self.comm.mpi_comm.barrier()
 
 
 class DynamicExampleModel(chainer.Chain):
@@ -206,3 +207,5 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
         chainer.testing.assert_allclose(
             self.optimizer.communicated_target.c.W.grad,
             (base + 11) * np.ones((4, 4)))
+        self.comm.mpi_comm.barrier()
+

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -85,6 +85,8 @@ class TestDoubleBufferingOptimizer(unittest.TestCase):
         chainer.testing.assert_allclose(
             self.optimizer.communicated_target.c.W.grad,
             (base + 5) * np.ones((5, 4)))
+        # barrier() requires before destructor of PureNcclCommunicator
+        # because communication may not be finished.
         self.comm.mpi_comm.barrier()
 
 
@@ -207,5 +209,6 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
         chainer.testing.assert_allclose(
             self.optimizer.communicated_target.c.W.grad,
             (base + 11) * np.ones((4, 4)))
+        # barrier() requires before destructor of PureNcclCommunicator
+        # because communication may not be finished.
         self.comm.mpi_comm.barrier()
-

--- a/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
@@ -102,7 +102,6 @@ class TestMultiNodeOptimizer(unittest.TestCase):
                                         (base + 1) * np.ones((4, 3)))
         chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
                                         (base + 2) * np.ones((5, 4)))
-        self.comm.mpi_comm.barrier()
 
 
 class DynamicExampleModel(chainer.Chain):
@@ -223,5 +222,3 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
                                         (base + 1) * np.ones((4, 3)))
         chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
                                         (base + 2) * np.ones((4, 4)))
-        self.comm.mpi_comm.barrier()
-

--- a/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
@@ -102,6 +102,7 @@ class TestMultiNodeOptimizer(unittest.TestCase):
                                         (base + 1) * np.ones((4, 3)))
         chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
                                         (base + 2) * np.ones((5, 4)))
+        self.comm.mpi_comm.barrier()
 
 
 class DynamicExampleModel(chainer.Chain):
@@ -222,3 +223,5 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
                                         (base + 1) * np.ones((4, 3)))
         chainer.testing.assert_allclose(self.optimizer.target.c.W.grad,
                                         (base + 2) * np.ones((4, 4)))
+        self.comm.mpi_comm.barrier()
+


### PR DESCRIPTION
This PR refactors initialization of communicator to remove unused mpi comm or nccl comm.
It solves https://github.com/chainer/chainermn/issues/224 

