### PR TITLE
Modify receivers in communicator to use cupy array

### DIFF
--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -109,11 +109,19 @@ def unpack_params(params, itemsize, attr_name, buffer, stream=None):
 
 def array_to_buffer_object(array):
     xp = chainer.cuda.get_array_module(array)
+
+    if xp is np:
+        return get_device_memory_pointer(array)
+    else:
+        return (get_device_memory_pointer(array), mpi4py.MPI.FLOAT)
+
+
+def get_device_memory_pointer(array):
+    xp = chainer.cuda.get_array_module(array)
     array = xp.ascontiguousarray(array)
 
     if xp is np:
         return array
     else:
         ffi = cffi.FFI()
-        return (ffi.buffer(ffi.cast('void *', array.data.ptr), array.nbytes),
-                mpi4py.MPI.FLOAT)
+        return ffi.buffer(ffi.cast('void *', array.data.ptr), array.nbytes)

--- a/chainermn/communicators/communicator_base.py
+++ b/chainermn/communicators/communicator_base.py
@@ -80,10 +80,10 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         '''All-to-all implementation for ndarray
 
         Args:
-            xs (tuple of numpy.ndarray)
+            xs (tuple of numpy/cupy array)
 
         Returns:
-            ys (tuple of numpy.ndarray):
+            ys (tuple of numpy/cupy array):
                 Received arrays. The length of tuple equals to
                 the communicator size.
 
@@ -126,13 +126,13 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         '''Broadcasts an ndarray from root process to all processes
 
         Args:
-            data (numpy.array): for root process, the data to broadcast.
+            data (numpy/cupy array): for root process, the data to broadcast.
                 For non-root processes, this argument is ignored.
             max_buf_len (int): Length of send buffer.
             root (int): the process who has the data to broadcast.
 
         Returns:
-            ys (numpy.ndarray) : The data sent from root process
+            ys (numpy/cupy array) : The data sent from root process
 
         '''
         raise NotImplementedError()
@@ -166,10 +166,10 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         over all processes, and cannot handle tuple data.
 
         Args:
-            x (numpy.array): Array to be gathered.
+            x (numpy/cupy array): Array to be gathered.
 
         Returns:
-            ys (tuple of numpy.ndarray): Received arrays.
+            ys (tuple of numpy/cupy array): Received arrays.
         """
         raise NotImplementedError()
 

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -129,7 +129,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         # Type check.
         for x in xs:
             _check_dtype('alltoall', x)
-        msgtype = _MessageType(xs)
+        _MessageType(xs)
 
         # Mediate #axes of arrays.
         sndims = numpy.array([x.ndim for x in xs], dtype=numpy.int32)
@@ -546,7 +546,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
             self.mpi_comm.Scatterv(
                 [sbuf, (slens, _cnt_to_dsp(slens)), mpi4py.MPI.FLOAT],
-                 _memory_utility.get_device_memory_pointer(rbuf), root)
+                _memory_utility.get_device_memory_pointer(rbuf), root)
 
             return rbuf.reshape(shape)
 

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -105,6 +105,12 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         invoke ``alltoall()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
+        If ``xs`` is numpy array, the received data will also be allocated
+        as numpy array. If ``xs`` is cupy array, the received data will also
+        be cupy array. In the latter case, please be aware that
+        the CUDA current device is intended one.
+        (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
         Args:
             xs (tuple of numpy.ndarray)
 
@@ -123,6 +129,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         # Type check.
         for x in xs:
             _check_dtype('alltoall', x)
+        msgtype = _MessageType(xs)
 
         # Mediate #axes of arrays.
         sndims = numpy.array([x.ndim for x in xs], dtype=numpy.int32)
@@ -257,6 +264,11 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         invoke ``broadcast()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
+        If ``bcast()`` is invoked with cupy array in the root process,
+        this method tries to allocate cupy array to receive data.
+        Please be aware that the CUDA current device is intended one.
+        (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
         Args:
             x (numpy.array): Array to be broadcasted.
             root (int): Rank of root process.
@@ -299,6 +311,12 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         communicator. All processes in the communicator are expected to
         invoke ``gather()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
+
+        If ``x`` is numpy array, the received data will also be allocated
+        as numpy array. If ``x`` is cupy array, the received data will also
+        be cupy array. In the latter case, please be aware that
+        the CUDA current device is intended one.
+        (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
 
         Args:
             x (numpy.array): Array to be gathered.
@@ -398,6 +416,12 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         Note that this method can only handle the same shapes of data
         over all processes, and cannot handle tuple data.
 
+        If ``x`` is numpy array, the received data will also be allocated
+        as numpy array. If ``x`` is cupy array, the received data will also
+        be cupy array. In the latter case, please be aware that
+        the CUDA current device is intended one.
+        (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
         Args:
             x (numpy.array): An array to apply allreduce operation.
 
@@ -458,6 +482,11 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         If ``xs`` is ``numpy.ndarrray``, it is splitted with the first
         axis and sent to different processes. For slave processes, ``xs``
         is allowed to be any value (will be ignored).
+
+        If ``scatter()`` is invoked with cupy array in the root process,
+        this method tries to allocate cupy array to receive data.
+        Please be aware that the CUDA current device is intended one.
+        (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
 
         Args:
             xs (tuple of numpy.array or numpy.array): Arrays to be scattered.

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -105,17 +105,17 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         invoke ``alltoall()``. This method relies on mpi4py fast communication
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
-        If ``xs`` is numpy array, the received data will also be allocated
-        as numpy array. If ``xs`` is cupy array, the received data will also
-        be cupy array. In the latter case, please be aware that
-        the CUDA current device is intended one.
+        If ``xs`` is numpy array, the returned array will also be allocated
+        as numpy array. Additionally, when ``xs`` is cupy array, the returned
+        array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
-            xs (tuple of numpy.ndarray)
+            xs (tuple of numpy/cupy array)
 
         Returns:
-            ys (tuple of numpy.ndarray):
+            ys (tuple of numpy/cupy array):
                 Received arrays. The length of tuple equals to
                 the communicator size.
         """
@@ -222,14 +222,18 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         chainer.Variable objects. Please be sure.
 
         If the corresponding ``send()`` is invoked with cupy array,
-        this method tries to allocate cupy array to receive data.
-        Please be aware that the CUDA current device is intended one.
+        the returned array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
             source (int): Target process specifier.
             tag (int): Message ID (MPI feature).
 
+        Returns:
+            data (tuple of numpy/cupy array or numpy/cupy array):
+                Received data. If ``send()`` is invoked with tuple data,
+                it is also tuple. Otherwise, it is a vanilla numpy/cupy array.
         """
 
         chainer.utils.experimental(
@@ -266,16 +270,16 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
         If ``bcast()`` is invoked with cupy array in the root process,
-        this method tries to allocate cupy array to receive data.
-        Please be aware that the CUDA current device is intended one.
+        the returned array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
-            x (numpy.array): Array to be broadcasted.
+            x (numpy/cupy array): Array to be broadcasted.
             root (int): Rank of root process.
 
         Returns:
-            ys (tuple of numpy.ndarray): Received arrays.
+            ys (tuple of numpy/cupy array): Received arrays.
         """
         chainer.utils.experimental(
             'chainermn.communicators.MpiCommunicatorBase.bcast')
@@ -314,17 +318,17 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         optimized for numpy arrays, as well as ``send()`` and ``recv()``.
 
         If ``x`` is numpy array, the received data will also be allocated
-        as numpy array. If ``x`` is cupy array, the received data will also
-        be cupy array. In the latter case, please be aware that
-        the CUDA current device is intended one.
+        as numpy array. Additionally, when ``x`` is cupy array, the returned
+        array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
-            x (numpy.array): Array to be gathered.
+            x (numpy/cupy array): Array to be gathered.
             root (int): Rank of root process.
 
         Returns:
-            ys (tuple of numpy.ndarray):
+            ys (tuple of numpy/cupy array):
                 Received arrays. ``None`` for non-root processes.
         """
         chainer.utils.experimental(
@@ -418,16 +422,16 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         over all processes, and cannot handle tuple data.
 
         If ``x`` is numpy array, the received data will also be allocated
-        as numpy array. If ``x`` is cupy array, the received data will also
-        be cupy array. In the latter case, please be aware that
-        the CUDA current device is intended one.
+        as numpy array. Additionally, when ``x`` is cupy array, the returned
+        array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
-            x (numpy.array): An array to apply allreduce operation.
+            x (numpy/cupy array): An array to apply allreduce operation.
 
         Returns:
-            ys (numpy.ndarray): An array that allreduce (currently SUM only)
+            ys (numpy/cupy array): An array that allreduce (currently SUM only)
                 has been applied.
 
         """
@@ -485,16 +489,16 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         is allowed to be any value (will be ignored).
 
         If ``scatter()`` is invoked with cupy array in the root process,
-        this method tries to allocate cupy array to receive data.
-        Please be aware that the CUDA current device is intended one.
+        the returned array will be placed at current device
         (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+        regardless of which device the argument is placed at remote nodes.
 
         Args:
-            xs (tuple of numpy.array or numpy.array): Arrays to be scattered.
+            xs (tuple of numpy/cupy array): Arrays to be scattered.
             root (int): Rank of root process.
 
         Returns:
-            ys (numpy.ndarray): Received arrays.
+            ys (numpy/cupy array): Received arrays.
         """
         chainer.utils.experimental(
             'chainermn.communicators.CommunicatorBase.scatter')

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -168,7 +168,6 @@ def allgather(comm, x):
     Args:
         comm: ChainerMN communicator.
         x (chainer.Variables): Variables to send.
-        device (int): Target device specifier.
 
     Returns:
         ys (list of chainer.Variables): Received variables.

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -70,14 +70,14 @@ class Bcast(chainer.Function):
             x, = inputs
         else:
             x = None
-        return self.comm.bcast(x, self.root)
+        return self.comm.bcast(x, self.root),
 
     def backward(self, inputs, grad_outputs):
         gx, = grad_outputs
         gxs = self.comm.gather(gx, self.root)
-        xp = cuda.get_array_module(gxs)
 
         if self.comm.rank == self.root:
+            xp = cuda.get_array_module(*gxs)
             gxs = xp.stack(gxs)
             return gxs.sum(axis=0),
         else:
@@ -105,7 +105,7 @@ class Gather(chainer.Function):
             return xp.array([], dtype=xp.float32),
 
     def backward(self, inputs, grad_outputs):
-        return self.comm.scatter(grad_outputs, self.root)
+        return self.comm.scatter(grad_outputs, self.root),
 
 
 class Scatter(chainer.Function):

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -1,6 +1,5 @@
 import chainer
 from chainer import cuda
-import numpy
 
 
 class AllGather(chainer.Function):
@@ -39,7 +38,6 @@ class AllToAll(chainer.Function):
     def backward(self, inputs, grad_outputs):
         assert self.comm.size == len(grad_outputs)
 
-        xp = cuda.get_array_module(*inputs)
         gys = tuple([gy for gy in grad_outputs])
         return self.comm.alltoall(gys)
 

--- a/chainermn/functions/collective_communication.py
+++ b/chainermn/functions/collective_communication.py
@@ -6,27 +6,17 @@ import numpy
 class AllGather(chainer.Function):
     """Collective all-gather communication."""
 
-    def __init__(self, comm, device):
+    def __init__(self, comm):
         chainer.utils.experimental('chainermn.functions.AllGather')
         self.comm = comm
-        self.device = device
 
     def forward(self, inputs):
         x, = inputs
-        ys = self.comm.allgather(x)
-
-        if isinstance(self.device, int) and self.device >= 0:
-            ys = tuple([cuda.to_gpu(y, device=self.device) for y in ys])
-
-        return ys
+        return self.comm.allgather(x)
 
     def backward(self, inputs, grad_outputs):
         xp = cuda.get_array_module(*inputs)
         gxs = self.comm.alltoall(grad_outputs)
-
-        if isinstance(self.device, int) and self.device >= 0:
-            gxs = tuple([cuda.to_gpu(gx, device=self.device) for gx in gxs])
-
         gx = xp.stack(gxs).sum(axis=0)
         return gx,
 
@@ -34,10 +24,9 @@ class AllGather(chainer.Function):
 class AllToAll(chainer.Function):
     """Collective all-to-all communication."""
 
-    def __init__(self, comm, device):
+    def __init__(self, comm):
         chainer.utils.experimental('chainermn.functions.AllToAll')
         self.comm = comm
-        self.device = device
 
     def forward(self, inputs):
         if len(inputs) != self.comm.size:
@@ -45,32 +34,23 @@ class AllToAll(chainer.Function):
                 'The length of inputs must be same as communicator size.')
 
         xs = tuple([x for x in inputs])
-        ys = self.comm.alltoall(xs)
-
-        if isinstance(self.device, int) and self.device >= 0:
-            ys = tuple([cuda.to_gpu(y, device=self.device) for y in ys])
-
-        return ys
+        return self.comm.alltoall(xs)
 
     def backward(self, inputs, grad_outputs):
         assert self.comm.size == len(grad_outputs)
 
         xp = cuda.get_array_module(*inputs)
-        with cuda.get_device_from_array(*inputs):
-            gys = tuple([gy for gy in grad_outputs])
-            gx = self.comm.alltoall(gys)
-            gx = [xp.array(_gx) for _gx in gx]
-            return tuple(gx)
+        gys = tuple([gy for gy in grad_outputs])
+        return self.comm.alltoall(gys)
 
 
 class Bcast(chainer.Function):
     """Collective broadcast communication."""
 
-    def __init__(self, comm, root, device):
+    def __init__(self, comm, root):
         chainer.utils.experimental('chainermn.functions.Bcast')
         self.comm = comm
         self.root = root
-        self.device = device
 
     def __call__(self, *inputs):
         xp = cuda.get_array_module(*inputs)
@@ -90,37 +70,27 @@ class Bcast(chainer.Function):
             x, = inputs
         else:
             x = None
-        x = self.comm.bcast(x, self.root)
-
-        if isinstance(self.device, int) and self.device >= 0:
-            x = cuda.to_gpu(x, device=self.device)
-
-        return x,
+        return self.comm.bcast(x, self.root)
 
     def backward(self, inputs, grad_outputs):
-        with cuda.get_device_from_array(*inputs):
-            gx, = grad_outputs
-            gxs = self.comm.gather(gx, self.root)
+        gx, = grad_outputs
+        gxs = self.comm.gather(gx, self.root)
+        xp = cuda.get_array_module(gxs)
 
-            if self.comm.rank == self.root:
-                gxs = numpy.stack(gxs)
-
-                if isinstance(self.device, int) and self.device >= 0:
-                    gxs = cuda.to_gpu(gxs, device=self.device)
-
-                return gxs.sum(axis=0),
-            else:
-                return None,
+        if self.comm.rank == self.root:
+            gxs = xp.stack(gxs)
+            return gxs.sum(axis=0),
+        else:
+            return None,
 
 
 class Gather(chainer.Function):
     """Collective gather communication."""
 
-    def __init__(self, comm, root, device):
+    def __init__(self, comm, root):
         chainer.utils.experimental('chainermn.functions.Gather')
         self.comm = comm
         self.root = root
-        self.device = device
 
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
@@ -128,9 +98,6 @@ class Gather(chainer.Function):
         ys = self.comm.gather(x, self.root)
 
         if self.comm.rank == self.root:
-            if isinstance(self.device, int) and self.device >= 0:
-                ys = tuple([cuda.to_gpu(y, device=self.device) for y in ys])
-
             return ys
 
         else:
@@ -138,23 +105,16 @@ class Gather(chainer.Function):
             return xp.array([], dtype=xp.float32),
 
     def backward(self, inputs, grad_outputs):
-        with cuda.get_device_from_array(*inputs):
-            gx = self.comm.scatter(grad_outputs, self.root)
-
-            if isinstance(self.device, int) and self.device >= 0:
-                gx = cuda.to_gpu(gx, device=self.device)
-
-            return gx,
+        return self.comm.scatter(grad_outputs, self.root)
 
 
 class Scatter(chainer.Function):
     """Collective scatter communication."""
 
-    def __init__(self, comm, root, device):
+    def __init__(self, comm, root):
         chainer.utils.experimental('chainermn.functions.Scatter')
         self.comm = comm
         self.root = root
-        self.device = device
 
     def __call__(self, *inputs):
         xp = cuda.get_array_module(*inputs)
@@ -175,40 +135,37 @@ class Scatter(chainer.Function):
         else:
             y = self.comm.scatter(None, self.root)
 
-        if isinstance(self.device, int) and self.device >= 0:
-            y = cuda.to_gpu(y, device=self.device)
-
         return y,
 
     def backward(self, inputs, grad_outputs):
         xp = cuda.get_array_module(*inputs)
-        with cuda.get_device_from_array(*inputs):
-            gy, = grad_outputs
-            gxs = self.comm.gather(gy, self.root)
+        gy, = grad_outputs
+        gxs = self.comm.gather(gy, self.root)
 
-            if self.comm.rank == self.root:
-                if isinstance(self.device, int) and self.device >= 0:
-                    gxs = tuple([cuda.to_gpu(gx, device=self.device)
-                                 for gx in gxs])
+        if self.comm.rank == self.root:
+            return gxs
 
-                return gxs
-
+        else:
+            # Slave processes need to maintain input/output shapes.
+            if inputs == ():
+                dummy_var = tuple([xp.array([], dtype=xp.float32)])
             else:
-                # Slave processes need to maintain input/output shapes.
-                if inputs == ():
-                    dummy_var = tuple([xp.array([], dtype=xp.float32)])
-                else:
-                    dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32)
-                                       for x in inputs])
-                return dummy_var
+                dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32)
+                                   for x in inputs])
+            return dummy_var
 
 
-def allgather(comm, x, device=-1):
+def allgather(comm, x):
     """Differentiable all-gather communication between workers.
 
     This function invokes gather communications among processes specified
     by the communicator. Backward will be invoked as well as the ordinary
     chainer functions, where gradients are reduced to each process.
+
+    The received array will be on the current CUDA device on the invoking
+    process if ``x`` is on GPU. Please be aware that the current CUDA device
+    is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
 
     Args:
         comm: ChainerMN communicator.
@@ -220,10 +177,10 @@ def allgather(comm, x, device=-1):
     """
     chainer.utils.experimental('chainermn.functions.all_gather')
 
-    return AllGather(comm, device)(x)
+    return AllGather(comm)(x)
 
 
-def alltoall(comm, xs, device=-1):
+def alltoall(comm, xs):
     """Differentiable all-to-all communication between workers.
 
     This function invokes all-to-all communications among processes specified
@@ -236,10 +193,14 @@ def alltoall(comm, xs, device=-1):
     Please refer to ``chainermn.functions.pseudo_connect`` about the detail
     of delegate variables.
 
+    The received array will be on the current CUDA device on the invoking
+    process if ``xs`` is on GPU. Please be aware that the current CUDA device
+    is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
     Args:
         comm: ChainerMN communicator.
         xs (list of chainer.Variables): Variables to send.
-        device (int): Target device specifier.
 
     Returns:
         ys (list of chainer.Variables): Received variables.
@@ -249,10 +210,10 @@ def alltoall(comm, xs, device=-1):
     if len(xs) != comm.size:
         raise ValueError('The length of xs must be same as communicator size.')
 
-    return AllToAll(comm, device)(*xs)
+    return AllToAll(comm)(*xs)
 
 
-def bcast(comm, x, root=0, device=-1):
+def bcast(comm, x, root=0):
     """Differentiable broadcast communication between workers.
 
     This function invokes broadcast communications among processes specified
@@ -260,10 +221,14 @@ def bcast(comm, x, root=0, device=-1):
     chainer functions, where gradients are gathered to the root process
     and summed up.
 
+    The received array will be on the current CUDA device if ``x`` on the
+    invoking process is on GPU. Please be aware that the current CUDA device
+    is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
     Args:
         comm: ChainerMN communicator.
         x (chainer.Variable): Variable to be sent.
-        device (int): Target device specifier.
 
     Returns:
         y (chainer.Variable): Broadcasted variable.
@@ -271,12 +236,12 @@ def bcast(comm, x, root=0, device=-1):
     chainer.utils.experimental('chainermn.functions.bcast')
 
     if comm.rank == root:
-        return Bcast(comm, root, device)(x)
+        return Bcast(comm, root)(x)
     else:
-        return Bcast(comm, root, device)()
+        return Bcast(comm, root)()
 
 
-def gather(comm, x, root=0, device=-1):
+def gather(comm, x, root=0):
     """Differentiable gather communication between workers.
 
     This function invokes gather communications among processes specified
@@ -284,10 +249,14 @@ def gather(comm, x, root=0, device=-1):
     chainer functions, where gradients are scattered from the root process
     to each slave.
 
+    The received array will be on the current CUDA device if ``x`` on the
+    root process is on GPU. Please be aware that the current CUDA device
+    is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
     Args:
         comm: ChainerMN communicator.
         x (chainer.Variable): Variable to be sent.
-        device (int): Target device specifier.
 
     Returns:
         ys (chainer.Variable):
@@ -295,22 +264,26 @@ def gather(comm, x, root=0, device=-1):
     """
     chainer.utils.experimental('chainermn.functions.gather')
 
-    return Gather(comm, root, device)(x)
+    return Gather(comm, root)(x)
 
 
-def scatter(comm, xs, root=0, device=-1):
+def scatter(comm, xs, root=0):
     """Differentiable scatter communication between workers.
 
     This function invokes scatter communications among processes specified
     by the communicator. Backward will be invoked as well as the ordinary
     chainer functions, where gradients are gathered to the root process.
 
+    The received array will be on the current CUDA device if ``xs`` on the
+    root process is on GPU. Please be aware that the current CUDA device
+    is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
+
     Args:
         comm: ChainerMN communicator.
         xs (list of chainer.Variable):
             Variables to be scattered for master process.
             ``None`` for slave process.
-        device (int): Target device specifier.
 
     Returns:
         y (chainer.Variable): Scattered variable.
@@ -318,6 +291,6 @@ def scatter(comm, xs, root=0, device=-1):
     chainer.utils.experimental('chainermn.functions.scatter')
 
     if comm.rank == root:
-        return Scatter(comm, root, device)(*xs)
+        return Scatter(comm, root)(*xs)
     else:
-        return Scatter(comm, root, device)()
+        return Scatter(comm, root)()

--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -36,23 +36,21 @@ class Send(chainer.Function):
     def backward(self, inputs, grad_outputs):
         xp = cuda.get_array_module(*inputs)
         dummy_grad = xp.array([], dtype=xp.float32)
-        with cuda.get_device_from_array(*inputs):
-            grad = self.comm.recv(self.peer_rank, self.peer_tag)
-            if isinstance(grad, tuple):
-                return tuple([xp.array(gy) for gy in grad] + [dummy_grad])
-            else:
-                return xp.array(grad), dummy_grad
+        grad = self.comm.recv(self.peer_rank, self.peer_tag)
+        if isinstance(grad, tuple):
+            return tuple([xp.array(gy) for gy in grad] + [dummy_grad])
+        else:
+            return xp.array(grad), dummy_grad
 
 
 class Recv(chainer.Function):
     """Receive elements from target process."""
 
-    def __init__(self, comm, peer_rank, peer_tag, device=-1):
+    def __init__(self, comm, peer_rank, peer_tag):
         chainer.utils.experimental('chainermn.functions.Recv')
         self.comm = comm
         self.peer_rank = peer_rank
         self.peer_tag = peer_tag
-        self.device = device
 
     def __call__(self, *inputs):
         xp = cuda.get_array_module(*inputs)
@@ -90,10 +88,7 @@ class Recv(chainer.Function):
         if not isinstance(data, tuple):
             data = tuple([data])
 
-        if isinstance(self.device, int) and self.device >= 0:
-            return tuple([cuda.to_gpu(x, device=self.device) for x in data])
-        else:
-            return data
+        return data
 
     def backward(self, inputs, grad_outputs):
         xp = cuda.get_array_module(*inputs)
@@ -157,13 +152,15 @@ def send(x, communicator, rank, tag=0):
     return delegate_variable
 
 
-def recv(
-        communicator, rank, delegate_variable=None, tag=0, device=-1,
-        force_tuple=False):
+def recv(communicator, rank, delegate_variable=None, tag=0, force_tuple=False):
     """Receive elements from target process.
 
     This function returns data received from target process. If ``backward()``
     is invoked, it will try to send gradients to the target process.
+    The received array will be on the current CUDA device if the corresponding
+    ``send()`` is invoked with arrays on GPU.
+    Please be aware that the current CUDA device is intended one.
+    (``https://docs-cupy.chainer.org/en/stable/tutorial/basic.html#current-device``)
 
     .. note::
         If you define non-connected computational graph on one process,
@@ -179,7 +176,6 @@ def recv(
         delegate_variable (chainer.Variable):
             Pointer to the other non-connected component.
         tag (int): Optional message ID (MPI feature).
-        device (int): Target device specifier.
         force_tuple (bool): If ``False`` (the default) a Variable will be
             returned when the number of outputs is one. Otherwise, this
             method returns a tuple even when the number of outputs is one.
@@ -201,15 +197,13 @@ def recv(
         res = Recv(
             communicator,
             peer_rank=rank,
-            peer_tag=tag,
-            device=device)()
+            peer_tag=tag)()
     else:
         delegate_variable.name = 'delegate_variable'
         res = Recv(
             communicator,
             peer_rank=rank,
-            peer_tag=tag,
-            device=device)(delegate_variable)
+            peer_tag=tag)(delegate_variable)
 
     if force_tuple and not isinstance(res, tuple):
         return tuple([res])

--- a/chainermn/links/multi_node_chain_list.py
+++ b/chainermn/links/multi_node_chain_list.py
@@ -207,8 +207,7 @@ class MultiNodeChainList(chainer.ChainList):
                         _x = chainermn.functions.recv(
                             self._comm,
                             rank=_rank_in,
-                            delegate_variable=delegate_variable,
-                            device=self._device_id)
+                            delegate_variable=delegate_variable)
 
                     xs.append(_x)
 

--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -53,8 +53,7 @@ class _MultiNodeNStepRNN(chainer.Chain):
         if self.rank_in is not None:
             cells = [chainermn.functions.recv(
                 self.communicator,
-                rank=self.rank_in,
-                device=self.actual_rnn._device_id)
+                rank=self.rank_in)
                 for _ in range(self.n_cells)]
 
         outputs = self.actual_rnn(*(tuple(cells) + inputs))

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -16,18 +16,16 @@ class TestCollectiveCommunication(unittest.TestCase):
 
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
-            self.device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
             self.communicator = chainermn.create_communicator('naive')
-            self.device = -1
 
         if self.communicator.size < 2:
             pytest.skip("This test is for multinode")
 
     def check_all_gather(self, xs):
         x = xs[self.communicator.rank]
-        ys = chainermn.functions.allgather(self.communicator, x, self.device)
+        ys = chainermn.functions.allgather(self.communicator, x)
         e = 0
         for i, y in enumerate(ys):
             e += chainer.functions.mean_squared_error(y, xs[i])
@@ -55,7 +53,7 @@ class TestCollectiveCommunication(unittest.TestCase):
         self.check_all_gather(xs)
 
     def check_all_to_all(self, xs):
-        ys = chainermn.functions.alltoall(self.communicator, xs, self.device)
+        ys = chainermn.functions.alltoall(self.communicator, xs)
 
         y = chainer.functions.sum(ys[0])
         for _y in ys[1:]:
@@ -91,10 +89,10 @@ class TestCollectiveCommunication(unittest.TestCase):
         root = 0
         if self.communicator.rank == root:
             y = chainermn.functions.bcast(
-                self.communicator, x, root, self.device)
+                self.communicator, x, root)
         else:
             y = chainermn.functions.bcast(
-                self.communicator, None, root, self.device)
+                self.communicator, None, root)
         e = chainer.functions.mean_squared_error(y, x)
         e.backward()
 
@@ -124,7 +122,7 @@ class TestCollectiveCommunication(unittest.TestCase):
 
         if self.communicator.rank == root:
             ys = chainermn.functions.gather(
-                self.communicator, x, root, self.device)
+                self.communicator, x, root)
             e = 0
             for i, y in enumerate(ys):
                 e += chainer.functions.mean_squared_error(y, xs[i])
@@ -136,7 +134,7 @@ class TestCollectiveCommunication(unittest.TestCase):
 
         else:
             phi = chainermn.functions.gather(
-                self.communicator, x, root, self.device)
+                self.communicator, x, root)
             phi.backward()
 
             # Check backward does not fall in deadlock.
@@ -183,7 +181,7 @@ class TestCollectiveCommunication(unittest.TestCase):
         y = chainermn.functions.scatter(
             self.communicator,
             xs if self.communicator.rank == root else None,
-            root, self.device)
+            root)
         x = xs[self.communicator.rank]
         e = chainer.functions.mean_squared_error(y, x)
         e.backward()

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -16,6 +16,7 @@ class TestCollectiveCommunication(unittest.TestCase):
 
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
+            self.device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
             self.communicator = chainermn.create_communicator('naive')

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -78,8 +78,7 @@ class TestPointToPointCommunication(unittest.TestCase):
 
         elif self.communicator.rank == self.communicator.size - 1:
             # Output process.
-            x = chainermn.functions.recv(
-                self.communicator, self.rank_recv, device=self.device)
+            x = chainermn.functions.recv(self.communicator, self.rank_recv)
             y = self.f(self.model(x))
             err = self.evaluation(y, self.x)
             err.backward()
@@ -94,8 +93,7 @@ class TestPointToPointCommunication(unittest.TestCase):
 
         else:
             # Intermediate processes.
-            x = chainermn.functions.recv(
-                self.communicator, self.rank_recv, device=self.device)
+            x = chainermn.functions.recv(self.communicator, self.rank_recv)
             y = self.f(self.model(x))
             err = chainermn.functions.send(
                 y, self.communicator, self.rank_send)
@@ -121,8 +119,7 @@ class TestPointToPointCommunication(unittest.TestCase):
             # Unless delegate_variable is used, backprop would stop here.
             x = chainermn.functions.recv(
                 self.communicator, self.rank_recv,
-                delegate_variable=dlg,
-                device=self.device)
+                delegate_variable=dlg)
             err = self.evaluation(x, t)
             err.backward()
 
@@ -131,8 +128,7 @@ class TestPointToPointCommunication(unittest.TestCase):
 
         else:
             # Intermediate processes.
-            x = chainermn.functions.recv(
-                self.communicator, self.rank_recv, device=self.device)
+            x = chainermn.functions.recv(self.communicator, self.rank_recv)
             y = self.f(self.model(x))
             err = chainermn.functions.send(
                 y, self.communicator, self.rank_send)
@@ -159,16 +155,14 @@ class TestPointToPointCommunication(unittest.TestCase):
 
         elif self.communicator.rank == self.communicator.size - 1:
             y = chainermn.functions.recv(
-                self.communicator, self.rank_recv, device=self.device,
-                force_tuple=True)
+                self.communicator, self.rank_recv, force_tuple=True)
             assert isinstance(y, tuple)
             z = functools.reduce(lambda x, y: x + y, y)
             err = self.evaluation(z, self.x)
             err.backward()
 
         else:
-            y = chainermn.functions.recv(
-                self.communicator, self.rank_recv, device=self.device)
+            y = chainermn.functions.recv(self.communicator, self.rank_recv)
             err = chainermn.functions.send(
                 y, self.communicator, self.rank_send)
             err.backward()


### PR DESCRIPTION
## Problem

The current communicator always returns `numpy` arrays when it received data (e.g. `recv`, `bcast`, etc.).
This is sometimes problematic in terms of communication speed, because p2p/collective communication always invoked by D2H/H2D memcpy, even though GPU-to-GPU communication is intended.
Received data should be allocated on GPU in case where the sender sends cupy arrays.

## Modifications

Modified `alltoall`, `recv`, `bcast`, `gather`, `allgather`, `allreduce`, `scatter` to
- allocate received data on GPU if needed (cf. `_memory_utility.get_device_memory_pointer`)
- remove device specifier and CUDA cast codes from the corresponding `chainermn.functions`