### PR TITLE
Enable MultiNodeIterator/MpiCommunicatorBase to handle general data type

### DIFF
--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -107,13 +107,13 @@ def unpack_params(params, itemsize, attr_name, buffer, stream=None):
         offset += size
 
 
-def array_to_buffer_object(array):
+def array_to_buffer_object(array, mpi_dtype=mpi4py.MPI.FLOAT):
     xp = chainer.cuda.get_array_module(array)
 
     if xp is np:
         return get_device_memory_pointer(array)
     else:
-        return (get_device_memory_pointer(array), mpi4py.MPI.FLOAT)
+        return (get_device_memory_pointer(array), mpi_dtype)
 
 
 def get_device_memory_pointer(array):

--- a/chainermn/iterators/multi_node_iterator.py
+++ b/chainermn/iterators/multi_node_iterator.py
@@ -5,11 +5,9 @@ import numpy
 def _is_valid_type(element):
     if isinstance(element, tuple) and len(element) == 2 \
             and hasattr(element[0], 'dtype') \
-            and element[0].dtype == numpy.float32 \
-            and hasattr(element[1], 'dtype') \
-            and element[1].dtype == numpy.float32:
+            and hasattr(element[1], 'dtype'):
         return True
-    elif hasattr(element, 'dtype') and element.dtype == numpy.float32:
+    elif hasattr(element, 'dtype'):
         return True
     return False
 
@@ -78,8 +76,8 @@ class _MultiNodeIteratorMaster(chainer.dataset.iterator.Iterator):
         if stop:
             raise StopIteration
         elif not is_valid_data_type:
-            raise TypeError('Multi node iterator supports numpy.float32 '
-                            'or tuple of numpy.float32 as the data type '
+            raise TypeError('Multi node iterator supports ndarray '
+                            'or tuple of scalars as the data type '
                             'of the batch element only.')
 
         if is_paired_dataset:
@@ -154,8 +152,8 @@ class _MultiNodeIteratorSlave(chainer.dataset.iterator.Iterator):
         if stop:
             raise StopIteration
         elif not is_valid_data_type:
-            raise TypeError('Multi node iterator supports numpy.float32 '
-                            'or tuple of numpy.float32 as the data type '
+            raise TypeError('Multi node iterator supports ndarray '
+                            'or tuple of scalars as the data type '
                             'of the batch element only.')
         if is_paired_dataset:
             xs = self.communicator.bcast(None, root=self.rank_master)


### PR DESCRIPTION
(rebased version of #265 )

Add `dtype` in `_MessageType` (see `mpi_communicator_base.py`) to
handle other dtype than `numpy.float32`.  Main change is to determine
MPI type based on `_MessageType` when calling MPI APIs, e.g.,

```python
self.mpi_comm.Gatherv(
    sbuf,
    [_memory_utility.get_device_memory_pointer(rbuf),
     (rlens, _cnt_to_dsp(rlens)), _get_mpi_type(msgtype)],
    root)
```

where `_get_mpi_type` converts `_MessageType` to MPI data type.

`MultiNodeIterator` is one of important use cases: Since
`MultiNodeIterator` broadcasts minibatches (consider `{(x: float32, y:
int32)}`-type dataset) every epoch, it needs to broadcast int32 array.