### PR TITLE
Improve performance of fetching device memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - pip install hacking==1.0.0
   - pip install pytest mock
   - pip install autopep8
-  - pip install mpi4py cffi
+  - pip install mpi4py
   - pip install chainer==${CHAINER_VER}
   - python setup.py develop
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import os
 
 
 install_requires = [
-    'cffi',
     'chainer >=3.5.0, !=4.0.0b2, != 4.0.0b1, != 4.0.0a1',
     'mpi4py',
 ]

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -80,7 +80,7 @@ class TestCollectiveCommunication(unittest.TestCase):
         chainer.cuda.get_device_from_id(self.device).use()
         data = [
             chainer.Variable(numpy.zeros(
-                (self.communicator.rank, i), dtype=numpy.float32))
+                (self.communicator.rank + 1, i + 1), dtype=numpy.float32))
             for i in range(self.communicator.size)]
         for x in data:
             x.to_gpu()


### PR DESCRIPTION
As results of benchmarks, `cffi` occupies a certain amount of the computation time in model-parallel architecture.
In order to fetch device memories, the current implementation is like
```python
ffi = cffi.FFI()
return ffi.buffer(ffi.cast('void *', array.data.ptr), array.nbytes)
```
but this can be improved as
```python
return ctypes.cast(
    array.data.ptr,
    ctypes.POINTER(ctypes.c_ubyte, array.nbytes)
).contents
```