### PR TITLE
added OMP_NUM_THREADS=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ script:
   - autopep8 -r . --global-config .pep8 | tee check_autopep8
   - test ! -s check_autopep8
   - export PYTHONWARNINGS='ignore::FutureWarning'
+  - export OMP_NUM_THREADS=1
   - (for NP in 1 2; do mpiexec ${NOBIND} -n ${NP} pytest -s -v -m 'not gpu and not slow' || exit $?; done)
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       READTHEDOCS=True python setup.py develop;


### PR DESCRIPTION
Travis CI fails with newly-deployed Python 3.6.5. 
This is because `numpy.dot` takes too long time. 

This PR fixes the issue by adding `OMP_NUM_THREADS=1` to the CI environment.