### PR TITLE
Revert ReadTheDocs latest site

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+ChainerMN
+=========
+
+All code and functionalities of ChainerMN have been merged into Chainer v5.
+Please refer to the `Distributed Deep Learning with ChainerMN <https://docs.chainer.org/en/stable/chainermn/>`_ section in the `Chainer documentation <https://docs.chainer.org/en/stable/>`_.
+
+Documentation of ChainerMN v1.3.x (for Chainer v4 and earlier) is still available `here <https://chainermn.readthedocs.io/en/stable/>`_.


### PR DESCRIPTION
Currently the latest page shows the default welcome message of RTD.

https://chainermn.readthedocs.io/en/latest/

I think it's better to forward users to the latest docs.

Related: https://github.com/chainer/chainer/pull/7044